### PR TITLE
fix(cli): honour port env, validate config, stop skill downgrade

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -16,7 +16,7 @@ The server stays attached to the terminal. Press `Ctrl+C` to stop.
 
 ### `tandem setup`
 
-Bare `tandem setup` prints setup guidance and points at the in-app integration wizard (the recommended path). `tandem setup --apply` writes Tandem's MCP entries to the integrations it detects (Claude Code and Claude Desktop) non-interactively, and installs the Claude Code skill at `~/.claude/skills/tandem/SKILL.md` (idempotent — refreshed on every run).
+Bare `tandem setup` prints setup guidance and points at the in-app integration wizard (the recommended path). `tandem setup --apply` writes Tandem's MCP entries to the integrations it detects (Claude Code and Claude Desktop) non-interactively, and installs the Claude Code skill at `~/.claude/skills/tandem/SKILL.md` (installed if absent, and re-written unless the installed copy is stamped with a newer version).
 
 ```bash
 tandem setup            # guidance only

--- a/docs/reviews/2026-09-02-v1-review/tracks/specs/F-doctor-1790.md
+++ b/docs/reviews/2026-09-02-v1-review/tracks/specs/F-doctor-1790.md
@@ -62,7 +62,8 @@ false in the safe direction and this fix makes false in the current wording.
   route still echoes nothing about the skill.
 
 - **`src/cli/setup.ts:178-183`** keeps `✓ ~/.claude/skills/tandem/SKILL.md` on a write and
-  otherwise prints, reading the result defensively (`result?.written === false`): *`⚠ kept the
+  otherwise prints (`if (!result.written)` — the result is non-nullable, so the optional chain the
+  first draft carried was dead weight and `/simplify` removed it): *`⚠ kept the
   installed skill (v<n> on disk is newer than this install's v<m>) — delete
   ~/.claude/skills/tandem/SKILL.md and re-run to replace it`*. **The remedy names deleting the
   file, never "upgrade Tandem to move it"** — no Tandem version moves a `version: 999` file, so

--- a/docs/reviews/2026-09-02-v1-review/tracks/specs/F-doctor-1790.md
+++ b/docs/reviews/2026-09-02-v1-review/tracks/specs/F-doctor-1790.md
@@ -84,6 +84,19 @@ makes false in the safe direction and this fix makes false in the current wordin
   the documented way. The response keeps echoing nothing about the skill, and the seam type stays
   `typeof installSkill`.
 
+- **`installSkill` itself logs the skip, so the surface that cannot repair it still leaves a
+  trace.** On the `newer-on-disk` return, one `console.error` naming both versions and the
+  version-independent remedy — *delete `~/.claude/skills/tandem/SKILL.md` and re-run*. Without it
+  the skip is invisible to the wizard route (which echoes nothing) and to the desktop population,
+  which is precisely the one that cannot run the CLI remedy: `cliAvailable`'s own rationale
+  (`src/cli/doctor.ts:~1250-1275`) records that the Tauri bundle ships no `dist/cli` and puts
+  nothing on PATH. `refreshExistingSkillIfStale` already records its outcome
+  (`lastSkillRefreshError` / `getSkillRefreshError()`), so this would otherwise be the only silent
+  skip in the pair. **No new route field, no seam-type change** — `console.error` goes to stderr,
+  which Critical Rule 3 requires anyway. The CLI then prints two lines (this one, plus setup.ts's
+  `⚠` below, which is the half that can name `--force` because the leaf does not know its caller);
+  that duplication is the accepted cost of the wizard path getting a trace at all.
+
 - **Return `SkillInstallResult`**: `{ written: true } | { written: false; reason: "newer-on-disk";
   onDiskVersion: number; bundledVersion: number }` (was `Promise<void>`), so the silent no-op is
   reportable. `src/cli/setup.ts:178-183` prints `✓ ~/.claude/skills/tandem/SKILL.md` on a write and,
@@ -102,7 +115,10 @@ makes false in the safe direction and this fix makes false in the current wordin
 - **Both `installSkill` mock sites move in the same commit, because the return-type change is a
   `typecheck:tests` failure — a step inside the required `check` job, not a runtime one:**
   - `tests/cli/run-setup-apply.test.ts:13-30` — the `vi.fn()` in the `apply.js` mock factory,
-    plus a spec whose mock resolves `{ written: false, … }`.
+    plus a spec whose mock resolves `{ written: false, … }`. **And `:73`, the per-test default in
+    the same file's `beforeEach`:** `vi.mocked(installSkill).mockReset().mockResolvedValue(undefined)`
+    — `undefined` is what every existing spec gets, and it is the value the retype rejects. It
+    becomes `mockResolvedValue({ written: true })`.
   - `tests/server/integrations/api-routes.test.ts:163` — the annotation
     `let installSkillSpy: ReturnType<typeof vi.fn<() => Promise<void>>>` — and `:168`, the
     `vi.fn(async () => {})` assigned into `deps.installSkill` at `:170`. Both become
@@ -110,6 +126,19 @@ makes false in the safe direction and this fix makes false in the current wordin
     **Do NOT widen the seam type at `api-routes.ts:159` to `() => Promise<unknown>` to silence
     this** — that erases the #1894 seam's type contract, which is the thing keeping the real
     `~/.claude/skills/tandem/SKILL.md` out of the suite.
+
+- **Two further `installSkill` references stay unchanged, and the spec says why so neither is
+  "tidied":**
+  - `tests/server/document-write-rearm.test.ts:225-231` is a census row
+    (`{ file: "server/integrations/apply.ts", key: "installSkill", count: 1, rearm: "n/a" }`)
+    asserted **by exact equality** at `:404`, and CLAUDE.md's file-watcher rule points at it. It
+    stays exactly as written: exactly one `atomicWrite` survives in `installSkill`, and the new
+    early return adds no write, so `count: 1` / `rearm: "n/a"` remain true. Adding a second write
+    site would red this *and* widen #1599's bound.
+  - `tests/server/integrations/refresh-skill.test.ts:104` calls `await installSkill({ homeOverride })`
+    as **setup** for the `>=`-preservation spec this Fix cites at `refresh-skill.test.ts:102-113`.
+    It still writes, because no file exists at that point (the ENOENT → create path), so the new
+    comparison never fires there. No edit.
 
 - **`tests/skill-instruction-contract.test.ts`**: one new spec pinning a single object literal
   `{ version: <the number already pinned in this file>, bodyHash: "<sha256 of the body, first 12
@@ -146,6 +175,14 @@ makes false in the safe direction and this fix makes false in the current wordin
    not `>=`, boundary. Write a mangled body carrying the current `version:` line and assert the
    file comes back as `SKILL_CONTENT`: this is the idempotent-repair case that `>=` would break,
    and it is the boundary a "consistency" refactor toward the refresher's `>=` would flip.
+
+   **Derive "the current `version:` line" from `SKILL_CONTENT`, not from `BUNDLED_SKILL_VERSION`.**
+   Neither `readSkillVersion` (`src/server/integrations/apply.ts:2076`) nor
+   `BUNDLED_SKILL_VERSION` (`:2083`) is exported, and `tests/cli/setup.test.ts` has no route to
+   either — **do not export new symbols from `apply.ts` for a test.** Copy the four-line local
+   `readSkillVersion` the precedent already uses (`tests/server/integrations/refresh-skill.test.ts:69`)
+   and run it over `SKILL_CONTENT`, which *is* exported (`src/cli/skill-content.ts:20`). The
+   mangled body is then `` `---\nversion: ${n}\n---\nmangled\n` `` for that `n`.
 4. On-disk `version: 999` **with `{ force: true }`** → overwritten, `{ written: true }`. Kills a
    comparison with no escape hatch, which would make a tampered stamp permanently un-repairable.
 5. No file → written (kills copying the refresher's ENOENT early-return into the create path).
@@ -166,8 +203,10 @@ makes false in the safe direction and this fix makes false in the current wordin
 ## Done when
 
 An older `setup --apply` cannot downgrade a newer installed skill and says so with a remedy that
-works; a re-run at the same version still rewrites the file; `--force` overwrites a newer stamp;
-one `atomicWrite` site remains in `installSkill`; a body-only skill edit reds
+works; **a skip leaves a stderr trace from `installSkill` itself, so the wizard/desktop path is
+not silent**; a re-run at the same version still rewrites the file; `--force` overwrites a newer
+stamp; one `atomicWrite` site remains in `installSkill` and
+`tests/server/document-write-rearm.test.ts`'s census row is untouched; a body-only skill edit reds
 `skill-instruction-contract`; item 2's measurement is in the PR body with its citations;
 `npm run typecheck:tests` green (the return-type change touches two mock sites); typecheck + the
 CLI, plugin and root suites green.
@@ -217,3 +256,34 @@ to `refreshExistingSkillIfStale`. A `force` parameter on the apply HTTP route. #
   prose line exceeds this wave's minimal-fix bar (a spec over ~120 lines is the stated smell). The
   doc edit stays in the Fix as an uncheckable but reviewed change; if `docs/cli.md` later earns a
   claims suite, this line is the first thing to put in it.
+
+## Review corrections (round 2)
+
+**Adopted**
+
+- *The downgrade guard is silent on the surface that cannot repair it — the wizard route echoes
+  nothing and the desktop population has no CLI to run `--force` against.* `installSkill` now
+  emits one `console.error` on the `newer-on-disk` return, naming both versions and the
+  version-independent remedy (delete the file and re-run). No new route field, no seam-type
+  change. `refreshExistingSkillIfStale` already records its outcome via `getSkillRefreshError()`,
+  so this closes the only remaining silent skip; `cliAvailable`'s rationale
+  (`src/cli/doctor.ts:~1250-1275`) is cited for why the desktop path needed it.
+- *The "both mock sites" enumeration misses the per-test default in the same file.*
+  `tests/cli/run-setup-apply.test.ts:73` —
+  `vi.mocked(installSkill).mockReset().mockResolvedValue(undefined)` — is now named in the Fix as
+  the value the retype rejects, becoming `mockResolvedValue({ written: true })`.
+- *Two further `installSkill` references were unnamed, one of them an exact-equality census the
+  CLAUDE.md file-watcher rule points at.* Both are now listed as **unchanged, and why**:
+  `tests/server/document-write-rearm.test.ts:225-231` stays `count: 1, rearm: "n/a"` because
+  exactly one `atomicWrite` survives (asserted by exact equality at `:404`), and
+  `tests/server/integrations/refresh-skill.test.ts:104` still writes because no file exists at
+  that point. Added to Done when.
+- *Test 3 needs `BUNDLED_SKILL_VERSION`, which is module-private with no route from
+  `tests/cli/setup.test.ts`.* Test 3 now derives the number in the test from the exported
+  `SKILL_CONTENT` (`src/cli/skill-content.ts:20`) with a local `readSkillVersion` copy, as
+  `tests/server/integrations/refresh-skill.test.ts:69` already does, and explicitly forbids
+  exporting new symbols from `apply.ts` for it.
+
+**Not adopted**
+
+- None.

--- a/docs/reviews/2026-09-02-v1-review/tracks/specs/F-doctor-1790.md
+++ b/docs/reviews/2026-09-02-v1-review/tracks/specs/F-doctor-1790.md
@@ -10,14 +10,14 @@ of the four** — item 4 of this issue is #1811's subject and is fixed there.
 
 Four items in the body; **two are live, one is already closed on master, one belongs to #1811.**
 
-1. **Live.** `installSkill` (`src/server/integrations/apply.ts`) is `mkdir` + a bare
+1. **Live.** `installSkill` (`src/server/integrations/apply.ts:2065-2071`) is `mkdir` + a bare
    `atomicWrite(SKILL_CONTENT, skillPath)` with no comparison. Its sibling
    `refreshExistingSkillIfStale` compares `readSkillVersion(on-disk)` against
    `BUNDLED_SKILL_VERSION` and writes only when the bundle is newer. So an **older** npm
    `tandem setup --apply` — which doctor prescribes for several conditions — silently downgrades
-   a newer installed skill, and overwrites a hand-edited one. This is not theoretical: the
-   `deps.installSkill` seam added by #1894 exists because the api-routes suite had downgraded the
-   operator's v15 install to v14 three times in one night.
+   a newer installed skill. This is not theoretical: the `deps.installSkill` seam added by #1894
+   exists because the api-routes suite had downgraded the operator's v15 install to v14 three
+   times in one night.
 2. **Already closed on master, measured, not re-fixed.** `.claude-plugin/plugin.json` is at
    `0.25.0` = `package.json`'s `0.25.0`; `.claude/skills/release/SKILL.md` §"The six version
    surfaces" item 2 already enumerates all **five** plugin.json values including the four
@@ -37,29 +37,80 @@ makes false in the safe direction and this fix makes false in the current wordin
 
 ## Fix
 
-- **`src/server/integrations/apply.ts`, `installSkill`.** Model: `refreshExistingSkillIfStale`,
-  reusing its `readSkillVersion` and `BUNDLED_SKILL_VERSION` — one comparison rule, not a second
-  copy. Keep `assertPathSafe` and `mkdir` exactly as they are. Between `mkdir` and the write:
-  `readFile(skillPath, "utf8")`; if it resolves and
-  `BUNDLED_SKILL_VERSION !== 0 && readSkillVersion(current) >= BUNDLED_SKILL_VERSION`, return
-  without writing. `ENOENT` → write (this is the **create** path — that is the one thing it must
-  not inherit from the refresher, which returns early on a missing file so generic server startup
-  never installs a standalone copy). Any other read error → write, preserving today's behaviour
-  for the consent-bearing installer. `BUNDLED_SKILL_VERSION === 0` → write, again unlike the
-  refresher: an unstamped bundle cannot be compared, and this call site has explicit user consent.
-  Exactly **one** `atomicWrite` call site survives — `tests/docs/config-writer-set-claims.test.ts`
+- **`src/server/integrations/apply.ts`, `installSkill`.** Signature becomes
+  `installSkill(opts: { homeOverride?: string; force?: boolean } = {})`. Model:
+  `refreshExistingSkillIfStale`, reusing its `readSkillVersion` and `BUNDLED_SKILL_VERSION` — one
+  comparison rule, not a second copy. Keep `assertPathSafe` and `mkdir` exactly as they are.
+  Between `mkdir` and the write: `readFile(skillPath, "utf8")`; if it resolves and
+  `!opts.force && BUNDLED_SKILL_VERSION !== 0 && readSkillVersion(current) > BUNDLED_SKILL_VERSION`,
+  return without writing. `ENOENT` → write (this is the **create** path — that is the one thing it
+  must not inherit from the refresher, which returns early on a missing file so generic server
+  startup never installs a standalone copy). Any other read error → write, preserving today's
+  behaviour for the consent-bearing installer. `BUNDLED_SKILL_VERSION === 0` → write, again unlike
+  the refresher: an unstamped bundle cannot be compared, and this call site has explicit user
+  consent. Exactly **one** `atomicWrite` call site survives — `tests/docs/config-writer-set-claims.test.ts`
   derives the accepted-writer set by call-site count, so adding a second would widen #1599's bound.
+
+- **Strictly `>`, not `>=`, and the difference is the whole safety story.**
+  `refreshExistingSkillIfStale` uses `>=` (`apply.ts:2156`) because it is the *silent background*
+  refresher whose own header (`:2112`) says "The wizard-driven `installSkill()` remains the
+  authoritative, consent-bearing installer" — its at-equal preservation is pinned by
+  `tests/server/integrations/refresh-skill.test.ts:102-113`. Collapsing the two would break the
+  installer in two ways at once, both hitting the *common* case: `skills/tandem/SKILL.md:3` is
+  `version: 15`, so **equal is what almost every run is**. A user on 0.25.0 who re-runs
+  `setup --apply` — which `setupApplyRemedy` (`src/cli/doctor.ts:1302`) prescribes for many
+  conditions — would be told "v15 on disk is newer than this install's v15" and sent to upgrade an
+  install that is already current: a warning the user cannot clear, which
+  `src/cli/doctor.ts:1938` names as the thing that teaches people to ignore a section. And
+  `setup --apply` would lose the ability to restore a hand-mangled `SKILL.md` that still carries
+  `version: 15`, which is today's repair path. With `>`, equality rewrites, idempotent repair
+  survives, and the `⚠` line below is only ever printed when it is true.
+
+- **`--force` is the escape hatch for a strictly-newer stamp.** `applySetup` passes the flag it
+  already parses: `await installSkill({ force: opts.force })` (`SetupOptions.force` exists at
+  `src/cli/setup.ts:69` and today reaches only `detectTargets`; `--force` already means "write
+  anyway", and the help text at `:100` already says "Honors --force"). Without it a
+  hand-edited or tampered file stamped `version: 999` would make the skill **permanently
+  un-repairable by the product** — `refreshExistingSkillIfStale` already skips it (`:2156`) and
+  `installSkill` would now skip it too, leaving nothing that can replace behavioural instruction
+  loaded into every user session. Note the overload in the code comment so it is not read as a
+  detection-only flag.
+
+- **`src/server/integrations/api-routes.ts` deliberately passes no `force`.** Line 1008 stays
+  `await (deps.installSkill ?? installSkill)()`, so the wizard defaults to `force: false` — same
+  doctrine as the absent request-body `homeOverride` (`apply.ts:2060-2064`, `api-routes.ts:151-159`):
+  an HTTP request must not be able to demand an overwrite. State the honest limit in the PR body —
+  the wizard cannot repair a `version: 999` file, and the CLI `--force` (or deleting the file) is
+  the documented way. The response keeps echoing nothing about the skill, and the seam type stays
+  `typeof installSkill`.
+
 - **Return `SkillInstallResult`**: `{ written: true } | { written: false; reason: "newer-on-disk";
   onDiskVersion: number; bundledVersion: number }` (was `Promise<void>`), so the silent no-op is
-  reportable. `src/cli/setup.ts` prints `✓ ~/.claude/skills/tandem/SKILL.md` on a write and
-  `⚠ kept the installed skill (v<n> on disk is newer than this install's v<m>) — upgrade Tandem
-  to move it` otherwise. Read it defensively (`result?.written === false`): the existing
-  `vi.fn()` mocks in `tests/cli/run-setup-apply.test.ts` resolve `undefined`, and those mocks are
-  updated in the same commit rather than relied on.
-- **`src/server/integrations/api-routes.ts` is unchanged.** It calls
-  `await (deps.installSkill ?? installSkill)()` and ignores the value; the response must keep
-  echoing nothing about the skill, and the `typeof installSkill` seam type follows automatically.
-  **Keep the #1894 seam** — no test may reach the real `~/.claude/skills/tandem/SKILL.md`.
+  reportable. `src/cli/setup.ts:178-183` prints `✓ ~/.claude/skills/tandem/SKILL.md` on a write and,
+  otherwise:
+
+  > `⚠ kept the installed skill (v<n> on disk is newer than this install's v<m>) — re-run with
+  > --force to overwrite it, or delete ~/.claude/skills/tandem/SKILL.md and re-run`
+
+  **The remedy must name `--force`, not "upgrade Tandem to move it".** No Tandem version moves a
+  file stamped `version: 999`; that sentence would be a dead-end fix line of exactly the kind
+  `src/cli/doctor.ts:1345-1360` records the doctrine against. Read the result defensively
+  (`result?.written === false`): the existing `vi.fn()` mocks in
+  `tests/cli/run-setup-apply.test.ts` resolve `undefined`, and those mocks are updated in the same
+  commit rather than relied on.
+
+- **Both `installSkill` mock sites move in the same commit, because the return-type change is a
+  `typecheck:tests` failure — a step inside the required `check` job, not a runtime one:**
+  - `tests/cli/run-setup-apply.test.ts:13-30` — the `vi.fn()` in the `apply.js` mock factory,
+    plus a spec whose mock resolves `{ written: false, … }`.
+  - `tests/server/integrations/api-routes.test.ts:163` — the annotation
+    `let installSkillSpy: ReturnType<typeof vi.fn<() => Promise<void>>>` — and `:168`, the
+    `vi.fn(async () => {})` assigned into `deps.installSkill` at `:170`. Both become
+    `Promise<SkillInstallResult>` / `vi.fn(async () => ({ written: true }) as SkillInstallResult)`.
+    **Do NOT widen the seam type at `api-routes.ts:159` to `() => Promise<unknown>` to silence
+    this** — that erases the #1894 seam's type contract, which is the thing keeping the real
+    `~/.claude/skills/tandem/SKILL.md` out of the suite.
+
 - **`tests/skill-instruction-contract.test.ts`**: one new spec pinning a single object literal
   `{ version: <the number already pinned in this file>, bodyHash: "<sha256 of the body, first 12
   hex>" }` — `createHash("sha256")` over the text **after** the closing `---` of the frontmatter,
@@ -72,12 +123,14 @@ makes false in the safe direction and this fix makes false in the current wordin
   it cannot mechanically prove the bump happened, because nothing in the working tree remembers
   the previous body. It converts a silent miss into a red test, which is what the taken decision
   asks for.
+
 - **`skills/tandem/SKILL.md` is NOT edited** (`skill: false` for this group), so its `version`
   literal does not move and the new hash is computed from HEAD's content.
+
 - **`docs/cli.md:19`**: replace "(idempotent — refreshed on every run)" with "(installed if
-  absent, and refreshed only when this install's skill is newer — a newer or hand-edited installed
-  skill is kept)". The `CLAUDE.md:273` conflation the issue also names no longer exists at HEAD
-  (`grep -n installSkill CLAUDE.md` is empty) — nothing to change there.
+  absent, and re-written unless the installed copy is stamped with a newer version — use
+  `--force` to overwrite that)". The `CLAUDE.md:273` conflation the issue also names no longer
+  exists at HEAD (`grep -n installSkill CLAUDE.md` is empty) — nothing to change there.
 
 ## Tests
 
@@ -89,27 +142,78 @@ makes false in the safe direction and this fix makes false in the current wordin
    `atomicWrite`; assert the bytes, not just the return value, so a fix that computes the verdict
    and writes anyway still fails.
 2. On-disk `version: 1` → overwritten with `SKILL_CONTENT`, `{ written: true }`.
-3. On-disk equal to `BUNDLED_SKILL_VERSION` → not written (the `>=`, not `>`, boundary).
-4. No file → written (kills copying the refresher's ENOENT early-return into the create path).
-5. The existing "overwrites existing file on re-run" spec (`"old content"`, no frontmatter →
+3. **On-disk equal to `BUNDLED_SKILL_VERSION` → IS rewritten**, `{ written: true }` — the `>`,
+   not `>=`, boundary. Write a mangled body carrying the current `version:` line and assert the
+   file comes back as `SKILL_CONTENT`: this is the idempotent-repair case that `>=` would break,
+   and it is the boundary a "consistency" refactor toward the refresher's `>=` would flip.
+4. On-disk `version: 999` **with `{ force: true }`** → overwritten, `{ written: true }`. Kills a
+   comparison with no escape hatch, which would make a tampered stamp permanently un-repairable.
+5. No file → written (kills copying the refresher's ENOENT early-return into the create path).
+6. The existing "overwrites existing file on re-run" spec (`"old content"`, no frontmatter →
    version 0) must stay green — an unversioned file is still upgraded.
-6. `tests/cli/run-setup-apply.test.ts`: the `installSkill` mock resolves `{ written: true }`; add
+7. `tests/cli/run-setup-apply.test.ts`: the `installSkill` mock resolves `{ written: true }`; add
    a case where it resolves `{ written: false, … }` and `applySetup` still completes and prints
-   the kept-skill line (kills a caller that dereferences the result unguarded).
-7. `tests/skill-instruction-contract.test.ts`: the hash spec itself. Mutation check for the PR
+   the kept-skill line (kills a caller that dereferences the result unguarded), and assert that
+   line names `--force` rather than "upgrade". Add a spec that `runSetup({ apply: true, force:
+   true })` calls the `installSkill` mock with `{ force: true }` — the only thing that pins the
+   flag is actually threaded.
+8. `tests/server/integrations/api-routes.test.ts`: the retyped spy, per the Fix. No behaviour
+   change asserted — the route still echoes nothing about the skill.
+9. `tests/skill-instruction-contract.test.ts`: the hash spec itself. Mutation check for the PR
    body — appending one line to a scratch copy of the body flips it red while the `version`
    assertion stays green.
 
 ## Done when
 
-An older `setup --apply` cannot downgrade a newer installed skill and says so; one `atomicWrite`
-site remains in `installSkill`; a body-only skill edit reds `skill-instruction-contract`;
-`docs/cli.md` matches the behaviour; item 2's measurement is in the PR body with its citations;
-typecheck + the CLI, plugin and root suites green.
+An older `setup --apply` cannot downgrade a newer installed skill and says so with a remedy that
+works; a re-run at the same version still rewrites the file; `--force` overwrites a newer stamp;
+one `atomicWrite` site remains in `installSkill`; a body-only skill edit reds
+`skill-instruction-contract`; item 2's measurement is in the PR body with its citations;
+`npm run typecheck:tests` green (the return-type change touches two mock sites); typecheck + the
+CLI, plugin and root suites green.
 
 ## Not in scope
 
 Moving the plugin's npx pin to `latest` (rejected by `plugin-manifest.test.ts`'s pinned-spec
 assertion and its stale-global rationale) or a doctor check for an *installed* plugin whose pin
 lags the running version — `bryan`. Hashing the bundled content into the frontmatter. Any change
-to `refreshExistingSkillIfStale`. #1790 item 4 (→ #1811).
+to `refreshExistingSkillIfStale`. A `force` parameter on the apply HTTP route. #1790 item 4
+(→ #1811).
+
+## Files touched
+
+`src/server/integrations/apply.ts`, `src/cli/setup.ts`, `docs/cli.md`,
+`tests/cli/setup.test.ts`, `tests/cli/run-setup-apply.test.ts`,
+`tests/server/integrations/api-routes.test.ts`, `tests/skill-instruction-contract.test.ts`.
+
+## Review corrections (round 1)
+
+**Adopted**
+
+- *`>=` plus the "newer than" wording turns every healthy re-run into a false warning and removes
+  the repair path for a corrupted-but-current skill.* The skip is now strictly `>`; the Fix
+  carries a paragraph on why the refresher's `>=` must not be copied (`version: 15` makes *equal*
+  the common case, and `>=` would print an unclearable warning and block idempotent repair). Test
+  3 is repointed to assert the opposite of the old spec: on-disk **equal** IS rewritten, with the
+  `version: 999` case kept as the skip.
+- *No escape hatch, so a tampered `version: 999` becomes permanently un-repairable.* `installSkill`
+  gains `force?: boolean`; `applySetup` passes the `--force` it already parses; new test 4 pins the
+  bypass, and test 7 pins that the flag is actually threaded. The wizard route deliberately keeps
+  `force: false` (no request-body force, mirroring the absent request-body `homeOverride`), and the
+  PR body states that limit.
+- *"upgrade Tandem to move it" is a dead-end remedy.* The kept-skill line now names `--force` or
+  deleting the file, with the `doctor.ts:1345-1360` doctrine cited; test 7 asserts the wording.
+- *The return-type change breaks a second mock the spec did not name, and it fails
+  `typecheck:tests` inside the required `check` job* (raised three times). Both sites are now
+  enumerated — `run-setup-apply.test.ts:13-30` and `api-routes.test.ts:163,168` — with an explicit
+  prohibition on widening the seam type at `api-routes.ts:159` to silence the error. Added to
+  Tests, Done when, and Files touched.
+
+**Not adopted**
+
+- *Add a one-assertion pin for the `docs/cli.md` wording.* The Done-when claim "`docs/cli.md`
+  matches the behaviour" is **dropped** instead — nothing in `tests/docs/` covers `docs/cli.md`
+  today, and standing up a new suite file for a single `not.toMatch(/refreshed on every run/)` on a
+  prose line exceeds this wave's minimal-fix bar (a spec over ~120 lines is the stated smell). The
+  doc edit stays in the Fix as an uncheckable but reviewed change; if `docs/cli.md` later earns a
+  claims suite, this line is the first thing to put in it.

--- a/docs/reviews/2026-09-02-v1-review/tracks/specs/F-doctor-1790.md
+++ b/docs/reviews/2026-09-02-v1-review/tracks/specs/F-doctor-1790.md
@@ -1,197 +1,104 @@
 # F-doctor — #1790 skill and plugin version skew
 
 Branch `fix/doctor-and-skill-version-skew-1806`. Closes #1790. Ledger:
-`docs/reviews/2026-09-02-v1-review/areas/upgrade-path.md:17-18` and
-`areas/skill-plugin.md:21`. The `[ran]` experiment for the skill-content row (per-tag `curl` +
-md5, `55d1e8ea` → `68fa0ce0` at unchanged `version: 4`) becomes the hash spec below. **Land last
-of the four** — item 4 of this issue is #1811's subject and is fixed there.
+`docs/reviews/2026-09-02-v1-review/areas/upgrade-path.md:17-18` and `areas/skill-plugin.md:21`.
+The `[ran]` experiment for the skill-content row (per-tag `curl` + md5, `55d1e8ea` → `68fa0ce0` at
+unchanged `version: 4`) becomes the hash spec below. **Land last of the four.**
 
 ## Problem
 
 Four items in the body; **two are live, one is already closed on master, one belongs to #1811.**
 
 1. **Live.** `installSkill` (`src/server/integrations/apply.ts:2065-2071`) is `mkdir` + a bare
-   `atomicWrite(SKILL_CONTENT, skillPath)` with no comparison. Its sibling
+   `atomicWrite(SKILL_CONTENT, skillPath)` with no comparison, while its sibling
    `refreshExistingSkillIfStale` compares `readSkillVersion(on-disk)` against
-   `BUNDLED_SKILL_VERSION` and writes only when the bundle is newer. So an **older** npm
-   `tandem setup --apply` — which doctor prescribes for several conditions — silently downgrades
-   a newer installed skill. This is not theoretical: the `deps.installSkill` seam added by #1894
-   exists because the api-routes suite had downgraded the operator's v15 install to v14 three
-   times in one night.
-2. **Already closed on master, measured, not re-fixed.** `.claude-plugin/plugin.json` is at
-   `0.25.0` = `package.json`'s `0.25.0`; `.claude/skills/release/SKILL.md` §"The six version
-   surfaces" item 2 already enumerates all **five** plugin.json values including the four
-   `tandem-editor@<version>` npx pins; `tests/plugin-manifest.test.ts:26` pins
-   `plugin.version === pkg.version` and `:55-56` / `:110` derive every npx spec from `pkg.version`;
-   `tests/plugin/plugin-version-pin.test.ts` is the dedicated drift guard. The release step and
-   the wiring test the track file asks for both exist — **add nothing.** What remains is the
-   *user's installed copy*: a plugin installed at 0.24.1 keeps pinning 0.24.1 until reinstalled,
-   which no repo-side guard can move. Recorded under `bryan`, not fixed here.
-3. **Live.** `tests/skill-instruction-contract.test.ts` pins the frontmatter `version` number
-   only, so a content-only edit at an unchanged version is invisible — the exact miss that made
-   v0.20.0/v0.20.1 never reach upgraders (the refresh gate is version-keyed).
+   `BUNDLED_SKILL_VERSION` (`:2156`). So an **older** npm `tandem setup --apply` — which doctor
+   prescribes for several conditions — silently downgrades a newer installed skill. Not
+   theoretical: #1894's `deps.installSkill` seam exists because the api-routes suite downgraded the
+   operator's v15 install to v14 three times in one night.
+2. **Already closed on master — measured, not re-fixed.** `plugin.json` is `0.25.0` =
+   `package.json`'s; `.claude/skills/release/SKILL.md` §"The six version surfaces" item 2
+   enumerates all five plugin.json values including the four npx pins; `plugin-manifest.test.ts:26`
+   pins `plugin.version === pkg.version` and `:55-56`/`:110` derive every npx spec from
+   `pkg.version`; `tests/plugin/plugin-version-pin.test.ts` is the dedicated drift guard. The
+   release step and wiring test the track file asks for both exist — **add nothing.** Only the
+   *user's installed copy* remains, which no repo-side guard moves (`bryan`).
+3. **Live.** `tests/skill-instruction-contract.test.ts` pins the frontmatter `version` number only
+   (`:80`), so a content-only edit at an unchanged version is invisible — the miss that made
+   v0.20.0/v0.20.1 never reach upgraders, since the refresh gate is version-keyed.
 4. Double toolset — **#1811**, not here.
 
-`docs/cli.md:19` also states the skill is "idempotent — refreshed on every run", which item 1
-makes false in the safe direction and this fix makes false in the current wording.
+`docs/cli.md:19` also calls the install "idempotent — refreshed on every run", which item 1 makes
+false in the safe direction and this fix makes false in the current wording.
 
 ## Fix
 
-- **`src/server/integrations/apply.ts`, `installSkill`.** Signature becomes
-  `installSkill(opts: { homeOverride?: string; force?: boolean } = {})`. Model:
-  `refreshExistingSkillIfStale`, reusing its `readSkillVersion` and `BUNDLED_SKILL_VERSION` — one
-  comparison rule, not a second copy. Keep `assertPathSafe` and `mkdir` exactly as they are.
+- **`installSkill` compares before writing.** Keep `assertPathSafe` and `mkdir` as they are.
   Between `mkdir` and the write: `readFile(skillPath, "utf8")`; if it resolves and
-  `!opts.force && BUNDLED_SKILL_VERSION !== 0 && readSkillVersion(current) > BUNDLED_SKILL_VERSION`,
-  return without writing. `ENOENT` → write (this is the **create** path — that is the one thing it
-  must not inherit from the refresher, which returns early on a missing file so generic server
-  startup never installs a standalone copy). Any other read error → write, preserving today's
-  behaviour for the consent-bearing installer. `BUNDLED_SKILL_VERSION === 0` → write, again unlike
-  the refresher: an unstamped bundle cannot be compared, and this call site has explicit user
-  consent. Exactly **one** `atomicWrite` call site survives — `tests/docs/config-writer-set-claims.test.ts`
-  derives the accepted-writer set by call-site count, so adding a second would widen #1599's bound.
+  `BUNDLED_SKILL_VERSION !== 0 && readSkillVersion(current) > BUNDLED_SKILL_VERSION`, return
+  without writing. Reuse `readSkillVersion` and `BUNDLED_SKILL_VERSION` — one comparison rule, not
+  a second copy. **`ENOENT` → write**: this is the *create* path, the one thing it must not inherit
+  from the refresher, which returns early on a missing file so generic server startup never
+  installs a standalone copy. Any other read error → write, preserving today's behaviour for the
+  consent-bearing installer; `BUNDLED_SKILL_VERSION === 0` → write, since an unstamped bundle
+  cannot be compared. **Exactly one `atomicWrite` call site survives** —
+  `tests/docs/config-writer-set-claims.test.ts` derives the accepted-writer set by call-site count,
+  so a second would widen #1599's bound.
 
-- **Strictly `>`, not `>=`, and the difference is the whole safety story.**
-  `refreshExistingSkillIfStale` uses `>=` (`apply.ts:2156`) because it is the *silent background*
-  refresher whose own header (`:2112`) says "The wizard-driven `installSkill()` remains the
-  authoritative, consent-bearing installer" — its at-equal preservation is pinned by
-  `tests/server/integrations/refresh-skill.test.ts:102-113`. Collapsing the two would break the
-  installer in two ways at once, both hitting the *common* case: `skills/tandem/SKILL.md:3` is
-  `version: 15`, so **equal is what almost every run is**. A user on 0.25.0 who re-runs
-  `setup --apply` — which `setupApplyRemedy` (`src/cli/doctor.ts:1302`) prescribes for many
-  conditions — would be told "v15 on disk is newer than this install's v15" and sent to upgrade an
-  install that is already current: a warning the user cannot clear, which
-  `src/cli/doctor.ts:1938` names as the thing that teaches people to ignore a section. And
-  `setup --apply` would lose the ability to restore a hand-mangled `SKILL.md` that still carries
-  `version: 15`, which is today's repair path. With `>`, equality rewrites, idempotent repair
-  survives, and the `⚠` line below is only ever printed when it is true.
+- **Strictly `>`, not `>=`.** The refresher's `>=` (`:2156`) belongs to the *silent background*
+  path, whose header (`:2112`) says `installSkill()` "remains the authoritative, consent-bearing
+  installer"; its at-equal preservation is pinned by `refresh-skill.test.ts:102-113`. Since
+  `skills/tandem/SKILL.md:3` is `version: 15`, **equal is what almost every run is**: `>=` would
+  tell a current user that v15 is newer than v15 and send them to upgrade an already-current
+  install — an unclearable warning of the kind `src/cli/doctor.ts:1938` names — and would remove
+  today's repair path for a hand-mangled `SKILL.md` that still carries `version: 15`.
 
-- **`--force` is the escape hatch for a strictly-newer stamp.** `applySetup` passes the flag it
-  already parses: `await installSkill({ force: opts.force })` (`SetupOptions.force` exists at
-  `src/cli/setup.ts:69` and today reaches only `detectTargets`; `--force` already means "write
-  anyway", and the help text at `:100` already says "Honors --force"). Without it a
-  hand-edited or tampered file stamped `version: 999` would make the skill **permanently
-  un-repairable by the product** — `refreshExistingSkillIfStale` already skips it (`:2156`) and
-  `installSkill` would now skip it too, leaving nothing that can replace behavioural instruction
-  loaded into every user session. Note the overload in the code comment so it is not read as a
-  detection-only flag.
+- **Return `Promise<SkillInstallResult>`** (was `Promise<void>`) so the no-op is reportable:
+  `{ written: true } | { written: false; onDiskVersion: number; bundledVersion: number }`, exported
+  as a **type** — it is the return half of #1894's seam contract (`api-routes.ts:159`). Do not
+  export `readSkillVersion` or `BUNDLED_SKILL_VERSION`, and do not widen the seam type to
+  `() => Promise<unknown>` to silence the retype: that erases the contract keeping the real
+  `~/.claude/skills/tandem/SKILL.md` out of the suite. `api-routes.ts:1008` is unchanged and the
+  route still echoes nothing about the skill.
 
-  **And say what the overload costs: `--force` already means something else here.**
-  `src/cli/setup.ts:116` passes it to `detectTargets({ force: opts.force })`, whose existing
-  meaning is about refused *write targets*, so a user passing `--force` for target reasons would
-  silently downgrade a strictly-newer `SKILL.md` and see only the plain `✓` line. So the
-  comparison runs **before** the force check, not instead of it, and the result carries what it
-  overrode: `{ written: true; overwroteNewer?: true; onDiskVersion; bundledVersion }`. `setup.ts`
-  prints one line for that case — *`⚠ overwrote the installed skill (v<n>) with this install's
-  v<m> because --force was passed`* — so the downgrade is never invisible. Read the file
-  unconditionally; the early return is what `force` skips.
+- **`src/cli/setup.ts:178-183`** keeps `✓ ~/.claude/skills/tandem/SKILL.md` on a write and
+  otherwise prints, reading the result defensively (`result?.written === false`): *`⚠ kept the
+  installed skill (v<n> on disk is newer than this install's v<m>) — delete
+  ~/.claude/skills/tandem/SKILL.md and re-run to replace it`*. **The remedy names deleting the
+  file, never "upgrade Tandem to move it"** — no Tandem version moves a `version: 999` file, so
+  that would be a dead-end fix line of the kind `src/cli/doctor.ts:1345-1360` argues against.
 
-- **`src/server/integrations/api-routes.ts` deliberately passes no `force`.** Line 1008 stays
-  `await (deps.installSkill ?? installSkill)()`, so the wizard defaults to `force: false` — same
-  doctrine as the absent request-body `homeOverride` (`apply.ts:2060-2064`, `api-routes.ts:151-159`):
-  an HTTP request must not be able to demand an overwrite. State the honest limit in the PR body —
-  the wizard cannot repair a `version: 999` file, and the CLI `--force` (or deleting the file) is
-  the documented way. The response keeps echoing nothing about the skill, and the seam type stays
-  `typeof installSkill`.
+- **Both mock sites move in the same commit** — the retype fails `typecheck:tests`, a step inside
+  the required `check` job: `tests/cli/run-setup-apply.test.ts:13-30` (the factory's `vi.fn()`) and
+  **`:73`**, the per-test `mockResolvedValue(undefined)` → `mockResolvedValue({ written: true })`;
+  `tests/server/integrations/api-routes.test.ts:163` (the `Promise<void>` annotation) and `:168`.
 
-- **`installSkill` itself logs the skip, so the surface that cannot repair it leaves a trace in
-  the log rather than returning silently.** Be precise about who reads it: the wizard path runs
-  inside the sidecar (`src/server/integrations/api-routes.ts:1008`), so this line lands in the
-  sidecar log, which a desktop user will not see. It makes the skip diagnosable after the fact; it
-  does not notify that population, and the PR body must say so rather than claiming coverage.
-  On the `newer-on-disk` return, one `console.error` naming both versions and the
-  version-independent remedy — *delete `~/.claude/skills/tandem/SKILL.md` and re-run*. Without it
-  the skip is invisible to the wizard route (which echoes nothing) and to the desktop population,
-  which is precisely the one that cannot run the CLI remedy: `cliAvailable`'s own rationale
-  (`src/cli/doctor.ts:~1250-1275`) records that the Tauri bundle ships no `dist/cli` and puts
-  nothing on PATH. `refreshExistingSkillIfStale` already records its outcome
-  (`lastSkillRefreshError` / `getSkillRefreshError()`), so this would otherwise be the only silent
-  skip in the pair. **No new route field, no seam-type change** — `console.error` goes to stderr,
-  which Critical Rule 3 requires anyway. The CLI then prints two lines (this one, plus setup.ts's
-  `⚠` below, which is the half that can name `--force` because the leaf does not know its caller);
-  that duplication is the accepted cost of the wizard path getting a trace at all.
+- **Two references stay unchanged, so neither is "tidied":**
+  `tests/server/document-write-rearm.test.ts:225-231` is a census row (`count: 1, rearm: "n/a"`)
+  asserted by exact equality at `:404` — still true, since the early return adds no write;
+  `refresh-skill.test.ts:104` calls `installSkill({ homeOverride })` as setup and still writes,
+  because no file exists there (the ENOENT create path).
 
-- **Return `SkillInstallResult`**: `{ written: true; overwroteNewer?: true; onDiskVersion?: number;
-  bundledVersion?: number } | { written: false; reason: "newer-on-disk"; onDiskVersion: number;
-  bundledVersion: number }` (was `Promise<void>`), so the silent no-op is reportable.
-  **`SkillInstallResult` is exported as a TYPE from `apply.ts`** — it is the return half of the
-  #1894 seam's contract (`installSkill?: typeof installSkill;`, `src/server/integrations/api-routes.ts:159`)
-  and the retyped spy below annotates with it. The prohibition further down covers **runtime**
-  symbols only: `readSkillVersion` and `BUNDLED_SKILL_VERSION` stay module-private.
-  `src/cli/setup.ts:178-183` prints `✓ ~/.claude/skills/tandem/SKILL.md` on a plain write, the
-  `overwroteNewer` line above when `--force` overrode a newer stamp, and otherwise:
+- **`tests/skill-instruction-contract.test.ts`** gains one spec pinning `{ version: 15, bodyHash:
+  "<first 12 hex of sha256>" }`. **15** is the number this file already pins at `:80`, matching
+  `skills/tandem/SKILL.md:3` — the sweep doc's environment table still says 14, but J1 landed the
+  bump; read the file. The hash covers the text **after** the frontmatter's closing `---`, with
+  `\r\n` normalised to `\n` first (this repo's CRLF-staleness hazard must not red the suite).
+  Excluding the frontmatter is deliberate: a version bump alone does not churn the hash, so the
+  loud case is exactly "body changed, version did not". The failure message names the move — bump
+  `version:` and update both literals together. **Honest limit** (comment + PR body): it forces a
+  deliberate edit at the spot that says what to do; it cannot prove the bump happened.
 
-  > `⚠ kept the installed skill (v<n> on disk is newer than this install's v<m>) — re-run with
-  > --force to overwrite it, or delete ~/.claude/skills/tandem/SKILL.md and re-run`
+  **This group is therefore NOT file-disjoint from group C.** That literal shares the file with
+  every skill-bumping group, and the wave-3 table pairs F-doctor with C on a stated
+  file-disjointness precondition (`docs/plans/2026-09-06-open-issues-sweep.md:67`; C's row carries
+  a skill bump). So **F-doctor lands before C**, and C's spec and ledger row are told to update
+  `bodyHash` alongside `version` in the same commit.
 
-  **The remedy must name `--force`, not "upgrade Tandem to move it".** No Tandem version moves a
-  file stamped `version: 999`; that sentence would be a dead-end fix line of exactly the kind
-  `src/cli/doctor.ts:1345-1360` records the doctrine against. Read the result defensively
-  (`result?.written === false`): the existing `vi.fn()` mocks in
-  `tests/cli/run-setup-apply.test.ts` resolve `undefined`, and those mocks are updated in the same
-  commit rather than relied on.
-
-- **Both `installSkill` mock sites move in the same commit, because the return-type change is a
-  `typecheck:tests` failure — a step inside the required `check` job, not a runtime one:**
-  - `tests/cli/run-setup-apply.test.ts:13-30` — the `vi.fn()` in the `apply.js` mock factory,
-    plus a spec whose mock resolves `{ written: false, … }`. **And `:73`, the per-test default in
-    the same file's `beforeEach`:** `vi.mocked(installSkill).mockReset().mockResolvedValue(undefined)`
-    — `undefined` is what every existing spec gets, and it is the value the retype rejects. It
-    becomes `mockResolvedValue({ written: true })`.
-  - `tests/server/integrations/api-routes.test.ts:163` — the annotation
-    `let installSkillSpy: ReturnType<typeof vi.fn<() => Promise<void>>>` — and `:168`, the
-    `vi.fn(async () => {})` assigned into `deps.installSkill` at `:170`. Both become
-    `Promise<SkillInstallResult>` / `vi.fn(async () => ({ written: true }) as SkillInstallResult)`.
-    **Do NOT widen the seam type at `api-routes.ts:159` to `() => Promise<unknown>` to silence
-    this** — that erases the #1894 seam's type contract, which is the thing keeping the real
-    `~/.claude/skills/tandem/SKILL.md` out of the suite.
-
-- **Two further `installSkill` references stay unchanged, and the spec says why so neither is
-  "tidied":**
-  - `tests/server/document-write-rearm.test.ts:225-231` is a census row
-    (`{ file: "server/integrations/apply.ts", key: "installSkill", count: 1, rearm: "n/a" }`)
-    asserted **by exact equality** at `:404`, and CLAUDE.md's file-watcher rule points at it. It
-    stays exactly as written: exactly one `atomicWrite` survives in `installSkill`, and the new
-    early return adds no write, so `count: 1` / `rearm: "n/a"` remain true. Adding a second write
-    site would red this *and* widen #1599's bound.
-  - `tests/server/integrations/refresh-skill.test.ts:104` calls `await installSkill({ homeOverride })`
-    as **setup** for the `>=`-preservation spec this Fix cites at `refresh-skill.test.ts:102-113`.
-    It still writes, because no file exists at that point (the ENOENT → create path), so the new
-    comparison never fires there. No edit.
-
-- **`tests/skill-instruction-contract.test.ts`**: one new spec pinning a single object literal
-  `{ version: 15, bodyHash: "<sha256 of the body, first 12 hex>" }` — **15** is the number this
-  file already pins at `tests/skill-instruction-contract.test.ts:80`
-  (`expect(skill).toMatch(/^version:\s*15$/m)`), matching `skills/tandem/SKILL.md:3`. (The sweep
-  doc's environment table still records 14; J1 landed the bump. Read the file, not the table.)
-
-  **This makes the group NOT file-disjoint from group C, and that must be handled before landing.**
-  The new `{version, bodyHash}` literal shares `tests/skill-instruction-contract.test.ts` with every
-  skill-bumping group, and the wave-3 table puts F-doctor and C in the same wave on the stated
-  precondition that groups in one wave are file-disjoint
-  (`docs/plans/2026-09-06-open-issues-sweep.md:67`, and C's row carries a "skill bump"). So:
-  **F-doctor lands before C**, and C's spec and ledger row are told to update the `bodyHash`
-  literal alongside the `version` literal in the same commit. Without that instruction C's skill
-  bump hands the suite a red hash with nothing explaining it.
-
-  The hash is `createHash("sha256")` over the text **after** the closing `---` of the frontmatter,
-  with `\r\n` normalised to `\n` first (this repo has a documented CRLF-staleness hazard; a
-  checkout artefact must not red the suite). Excluding the frontmatter is deliberate: a version
-  bump alone then does not churn the hash, so the loud case is precisely "body changed, version
-  did not". The failure message names the required move: *bump `version:` in
-  `skills/tandem/SKILL.md` and update both literals together*. **Honest limit, state it in the
-  comment and the PR body:** this forces a deliberate edit at the exact spot that says what to do;
-  it cannot mechanically prove the bump happened, because nothing in the working tree remembers
-  the previous body. It converts a silent miss into a red test, which is what the taken decision
-  asks for.
-
-- **`skills/tandem/SKILL.md` is NOT edited** (`skill: false` for this group), so its `version`
-  literal does not move and the new hash is computed from HEAD's content.
-
-- **`docs/cli.md:19`**: replace "(idempotent — refreshed on every run)" with "(installed if
-  absent, and re-written unless the installed copy is stamped with a newer version — use
-  `--force` to overwrite that)". The `CLAUDE.md:273` conflation the issue also names no longer
-  exists at HEAD (`grep -n installSkill CLAUDE.md` is empty) — nothing to change there.
+- **`skills/tandem/SKILL.md` is NOT edited** (`skill: false`), so the hash comes from HEAD.
+- **`docs/cli.md:19`**: "(idempotent — refreshed on every run)" → "(installed if absent, and
+  re-written unless the installed copy is stamped with a newer version)". The `CLAUDE.md:273`
+  conflation the issue names no longer exists at HEAD (`grep -n installSkill CLAUDE.md` is empty).
 
 ## Tests
 
@@ -199,173 +106,67 @@ makes false in the safe direction and this fix makes false in the current wordin
 **never the real home**):
 
 1. On-disk `version: 999` → the file is **byte-identical** afterwards and the result is
-   `{ written: false, reason: "newer-on-disk" }`. The single spec that kills the bare
-   `atomicWrite`; assert the bytes, not just the return value, so a fix that computes the verdict
-   and writes anyway still fails. **Plus the stderr trace:**
-   `const errSpy = vi.spyOn(console, "error").mockImplementation(() => {})`, and the captured text
-   names both version numbers and `~/.claude/skills/tandem/SKILL.md`. Nothing else asserts
-   `installSkill`'s own log, so without this the trace can be dropped in review or by `/simplify`
-   with the suite green — which is the silent-skip condition the Fix added it to close.
+   `{ written: false, onDiskVersion: 999, bundledVersion: <n> }`. Assert the bytes, not just the
+   return value, so a fix that computes the verdict and writes anyway still fails.
 2. On-disk `version: 1` → overwritten with `SKILL_CONTENT`, `{ written: true }`.
-3. **On-disk equal to `BUNDLED_SKILL_VERSION` → IS rewritten**, `{ written: true }` — the `>`,
-   not `>=`, boundary. Write a mangled body carrying the current `version:` line and assert the
-   file comes back as `SKILL_CONTENT`: this is the idempotent-repair case that `>=` would break,
-   and it is the boundary a "consistency" refactor toward the refresher's `>=` would flip.
-
-   **Derive "the current `version:` line" from `SKILL_CONTENT`, not from `BUNDLED_SKILL_VERSION`.**
-   Neither `readSkillVersion` (`src/server/integrations/apply.ts:2076`) nor
-   `BUNDLED_SKILL_VERSION` (`:2083`) is exported, and `tests/cli/setup.test.ts` has no route to
-   either — **do not export new symbols from `apply.ts` for a test.** Copy the four-line local
-   `readSkillVersion` the precedent already uses (`tests/server/integrations/refresh-skill.test.ts:69`)
-   and run it over `SKILL_CONTENT`, which *is* exported (`src/cli/skill-content.ts:20`). The
-   mangled body is then `` `---\nversion: ${n}\n---\nmangled\n` `` for that `n`.
-4. On-disk `version: 999` **with `{ force: true }`** → overwritten, and the result is
-   `{ written: true, overwroteNewer: true, onDiskVersion: 999, bundledVersion: <n> }`. Kills a
-   comparison with no escape hatch (which would make a tampered stamp permanently un-repairable)
-   **and** kills a `force` that short-circuits the read, which is what would make the `--force`
-   overload silently downgrade a newer skill for a user who passed the flag for target reasons.
-5. No file → written (kills copying the refresher's ENOENT early-return into the create path).
-6. The existing "overwrites existing file on re-run" spec (`"old content"`, no frontmatter →
-   version 0) must stay green — an unversioned file is still upgraded.
-7. `tests/cli/run-setup-apply.test.ts`: the `installSkill` mock resolves `{ written: true }`; add
-   a case where it resolves `{ written: false, … }` and `applySetup` still completes and prints
-   the kept-skill line (kills a caller that dereferences the result unguarded), and assert that
-   line names `--force` rather than "upgrade". Add a spec that `runSetup({ apply: true, force:
-   true })` calls the `installSkill` mock with `{ force: true }` — the only thing that pins the
-   flag is actually threaded. **And a spec where the mock resolves
-   `{ written: true, overwroteNewer: true, onDiskVersion: 999, bundledVersion: 15 }` → setup prints
-   the overwrote-newer line naming both numbers**, which is what keeps a `--force` passed for
-   target reasons from silently downgrading the skill behind a plain `✓`.
-8. `tests/server/integrations/api-routes.test.ts`: the retyped spy, per the Fix. No behaviour
-   change asserted — the route still echoes nothing about the skill.
-9. `tests/skill-instruction-contract.test.ts`: the hash spec itself. Mutation check for the PR
-   body — appending one line to a scratch copy of the body flips it red while the `version`
-   assertion stays green.
+3. **On-disk equal to the bundled version → IS rewritten** — the `>`, not `>=`, boundary and the
+   idempotent-repair case. Write a mangled body carrying the current `version:` line, assert the
+   file comes back as `SKILL_CONTENT`. **Derive that number from the exported `SKILL_CONTENT`**
+   (`src/cli/skill-content.ts:20`) with the four-line local `readSkillVersion` copy the precedent
+   already uses (`refresh-skill.test.ts:69`) — no new export from `apply.ts` for a test.
+4. No file → written (kills copying the refresher's ENOENT early return into the create path).
+5. The existing "overwrites existing file on re-run" spec (no frontmatter → version 0) stays green.
+6. `tests/cli/run-setup-apply.test.ts`: the default mock resolves `{ written: true }`; one spec
+   where it resolves `{ written: false, … }` → `applySetup` still completes and prints the
+   kept-skill line naming deletion (kills a caller that dereferences the result unguarded).
+7. `tests/server/integrations/api-routes.test.ts`: the retyped spy. No behaviour change asserted.
+8. `tests/skill-instruction-contract.test.ts`: the hash spec. Mutation check for the PR body —
+   appending a line to a scratch copy of the body reds it while the `version` assertion stays green.
 
 ## Done when
 
 An older `setup --apply` cannot downgrade a newer installed skill and says so with a remedy that
-works; **a skip leaves a trace in the server log rather than returning silently** — the honest
-limit, which the PR body must also carry: the wizard path runs inside the sidecar
-(`src/server/integrations/api-routes.ts:1008`), so that `console.error` reaches the sidecar log,
-not the desktop user, and the route still echoes nothing about the skill; a re-run at the same
-version still rewrites the file; `--force` overwrites a newer stamp **and says which version it
-overwrote**; one `atomicWrite` site remains in `installSkill` and
-`tests/server/document-write-rearm.test.ts`'s census row is untouched; a body-only skill edit reds
+works; a re-run at the same version still rewrites; one `atomicWrite` site remains and
+`document-write-rearm.test.ts`'s census row is untouched; a body-only skill edit reds
 `skill-instruction-contract`; item 2's measurement is in the PR body with its citations;
-`npm run typecheck:tests` green (the return-type change touches two mock sites); typecheck + the
-CLI, plugin and root suites green.
+`npm run typecheck:tests`, typecheck and the CLI, plugin and root suites green.
 
 ## Not in scope
 
-Moving the plugin's npx pin to `latest` (rejected by `plugin-manifest.test.ts`'s pinned-spec
-assertion and its stale-global rationale) or a doctor check for an *installed* plugin whose pin
-lags the running version — `bryan`. Hashing the bundled content into the frontmatter. Any change
-to `refreshExistingSkillIfStale`. A `force` parameter on the apply HTTP route. #1790 item 4
-(→ #1811).
+Moving the plugin's npx pin to `latest` (rejected by `plugin-manifest.test.ts`). Hashing the
+bundled content into the frontmatter. Any change to `refreshExistingSkillIfStale`. Item 4 (→ #1811).
+
+## For Bryan
+
+- A plugin installed at 0.24.1 keeps pinning `tandem-editor@0.24.1` until reinstalled; no repo-side
+  guard moves a user's installed copy, and a doctor check for it is a new surface.
+- The wizard route cannot repair a `SKILL.md` stamped `version: 999`; deleting the file and
+  re-running is the remedy, and `setup --apply` is the surface that says so.
 
 ## Files touched
 
-`src/server/integrations/apply.ts`, `src/cli/setup.ts`, `docs/cli.md`,
-`tests/cli/setup.test.ts`, `tests/cli/run-setup-apply.test.ts`,
-`tests/server/integrations/api-routes.test.ts`, `tests/skill-instruction-contract.test.ts`.
+`src/server/integrations/apply.ts`, `src/cli/setup.ts`, `docs/cli.md`, `tests/cli/setup.test.ts`,
+`tests/cli/run-setup-apply.test.ts`, `tests/server/integrations/api-routes.test.ts`,
+`tests/skill-instruction-contract.test.ts`.
 
-## Review corrections (round 1)
+## Review corrections (scope cut)
 
-**Adopted**
+**Removed**
 
-- *`>=` plus the "newer than" wording turns every healthy re-run into a false warning and removes
-  the repair path for a corrupted-but-current skill.* The skip is now strictly `>`; the Fix
-  carries a paragraph on why the refresher's `>=` must not be copied (`version: 15` makes *equal*
-  the common case, and `>=` would print an unclearable warning and block idempotent repair). Test
-  3 is repointed to assert the opposite of the old spec: on-disk **equal** IS rewritten, with the
-  `version: 999` case kept as the skip.
-- *No escape hatch, so a tampered `version: 999` becomes permanently un-repairable.* `installSkill`
-  gains `force?: boolean`; `applySetup` passes the `--force` it already parses; new test 4 pins the
-  bypass, and test 7 pins that the flag is actually threaded. The wizard route deliberately keeps
-  `force: false` (no request-body force, mirroring the absent request-body `homeOverride`), and the
-  PR body states that limit.
-- *"upgrade Tandem to move it" is a dead-end remedy.* The kept-skill line now names `--force` or
-  deleting the file, with the `doctor.ts:1345-1360` doctrine cited; test 7 asserts the wording.
-- *The return-type change breaks a second mock the spec did not name, and it fails
-  `typecheck:tests` inside the required `check` job* (raised three times). Both sites are now
-  enumerated — `run-setup-apply.test.ts:13-30` and `api-routes.test.ts:163,168` — with an explicit
-  prohibition on widening the seam type at `api-routes.ts:159` to silence the error. Added to
-  Tests, Done when, and Files touched.
+- *The `force` escape hatch and everything it dragged in* — `installSkill({ force })`, the
+  `--force` overload analysis, the `overwroteNewer`/`onDiskVersion`/`bundledVersion` success
+  fields, setup's second `⚠` line, and the two force specs. The issue asks for a version
+  comparison; the escape hatch it needs is "delete the file and re-run", which the kept-skill line
+  prints and which no flag semantics can silently misfire.
+- *The `console.error` trace inside `installSkill`*, and the spy spec that kept it alive. The spec
+  itself conceded it reaches the sidecar log, not the desktop user; the user-visible surface
+  (`setup --apply`) still prints the skip.
+- *The three round-by-round correction logs.*
 
-**Not adopted**
+**Kept**
 
-- *Add a one-assertion pin for the `docs/cli.md` wording.* The Done-when claim "`docs/cli.md`
-  matches the behaviour" is **dropped** instead — nothing in `tests/docs/` covers `docs/cli.md`
-  today, and standing up a new suite file for a single `not.toMatch(/refreshed on every run/)` on a
-  prose line exceeds this wave's minimal-fix bar (a spec over ~120 lines is the stated smell). The
-  doc edit stays in the Fix as an uncheckable but reviewed change; if `docs/cli.md` later earns a
-  claims suite, this line is the first thing to put in it.
-
-## Review corrections (round 2)
-
-**Adopted**
-
-- *The downgrade guard is silent on the surface that cannot repair it — the wizard route echoes
-  nothing and the desktop population has no CLI to run `--force` against.* `installSkill` now
-  emits one `console.error` on the `newer-on-disk` return, naming both versions and the
-  version-independent remedy (delete the file and re-run). No new route field, no seam-type
-  change. `refreshExistingSkillIfStale` already records its outcome via `getSkillRefreshError()`,
-  so this closes the only remaining silent skip; `cliAvailable`'s rationale
-  (`src/cli/doctor.ts:~1250-1275`) is cited for why the desktop path needed it.
-- *The "both mock sites" enumeration misses the per-test default in the same file.*
-  `tests/cli/run-setup-apply.test.ts:73` —
-  `vi.mocked(installSkill).mockReset().mockResolvedValue(undefined)` — is now named in the Fix as
-  the value the retype rejects, becoming `mockResolvedValue({ written: true })`.
-- *Two further `installSkill` references were unnamed, one of them an exact-equality census the
-  CLAUDE.md file-watcher rule points at.* Both are now listed as **unchanged, and why**:
-  `tests/server/document-write-rearm.test.ts:225-231` stays `count: 1, rearm: "n/a"` because
-  exactly one `atomicWrite` survives (asserted by exact equality at `:404`), and
-  `tests/server/integrations/refresh-skill.test.ts:104` still writes because no file exists at
-  that point. Added to Done when.
-- *Test 3 needs `BUNDLED_SKILL_VERSION`, which is module-private with no route from
-  `tests/cli/setup.test.ts`.* Test 3 now derives the number in the test from the exported
-  `SKILL_CONTENT` (`src/cli/skill-content.ts:20`) with a local `readSkillVersion` copy, as
-  `tests/server/integrations/refresh-skill.test.ts:69` already does, and explicitly forbids
-  exporting new symbols from `apply.ts` for it.
-
-**Not adopted**
-
-- None.
-
-## Review corrections (round 3)
-
-**Adopted**
-
-- **BLOCKING** *The `bodyHash` spec lands in `tests/skill-instruction-contract.test.ts` — the file
-  group C must also edit in the same wave — and the version literal it derives from is already 15,
-  not the 14 the sweep doc records.* The Fix now names the concrete value (15, at
-  `tests/skill-instruction-contract.test.ts:80`, matching `skills/tandem/SKILL.md:3`), notes that
-  the sweep doc's environment table is stale because J1 landed the bump, and states plainly that
-  this group is **not** file-disjoint from C against
-  `docs/plans/2026-09-06-open-issues-sweep.md:67`: F-doctor lands before C, and C's spec and ledger
-  row must be told to update the `bodyHash` literal alongside the `version` literal in the same
-  commit.
-- *`--force` can silently downgrade a strictly-newer installed skill: the flag is already parsed
-  for `detectTargets` (target-refusal semantics, `src/cli/setup.ts:116`), so a user passing it for
-  that reason gets the plain `✓` with no sign a newer `SKILL.md` was overwritten.* The comparison
-  now runs **before** the force check; the result carries
-  `{ written: true, overwroteNewer: true, onDiskVersion, bundledVersion }`; `setup.ts` prints a
-  line naming both versions; test 4 asserts the fields and test 7 gains the printed-line spec.
-- *Done-when claimed the stderr trace makes "the wizard/desktop path not silent", which overstates
-  what the desktop population sees — the wizard route runs in the sidecar and its stderr goes to
-  the sidecar log.* Both the Fix bullet and Done-when are reworded to the checkable property (a
-  skip leaves a trace in the server log rather than returning silently), with the honest limit
-  stated and required in the PR body.
-- *The spec forbids exporting new symbols from `apply.ts` for a test while its own retype requires
-  the `SkillInstallResult` type in `tests/server/integrations/api-routes.test.ts`.* The return-type
-  bullet now says `SkillInstallResult` is exported as a **type** (it is the return half of the
-  #1894 seam contract) and scopes the prohibition to runtime symbols — `readSkillVersion` and
-  `BUNDLED_SKILL_VERSION`.
-- *Done-when requires a stderr trace on the skip and no spec asserted it, so it could be dropped
-  in review or by `/simplify` with the suite green.* Test 1 now spies `console.error` and asserts
-  the captured text names both version numbers and `~/.claude/skills/tandem/SKILL.md`.
-
-**Not adopted**
-
-- None.
+The comparison with strict `>`; the ENOENT/create and unstamped-bundle carve-outs; the
+single-`atomicWrite` constraint; the two named mock sites; the two deliberately-unchanged
+references; the `bodyHash` spec — issue item 3 — carrying the outstanding finding's fix in full
+(literal is 15, not the sweep doc's stale 14; this group is not file-disjoint from C, lands first,
+and C updates both literals together).

--- a/docs/reviews/2026-09-02-v1-review/tracks/specs/F-doctor-1790.md
+++ b/docs/reviews/2026-09-02-v1-review/tracks/specs/F-doctor-1790.md
@@ -76,6 +76,16 @@ makes false in the safe direction and this fix makes false in the current wordin
   loaded into every user session. Note the overload in the code comment so it is not read as a
   detection-only flag.
 
+  **And say what the overload costs: `--force` already means something else here.**
+  `src/cli/setup.ts:116` passes it to `detectTargets({ force: opts.force })`, whose existing
+  meaning is about refused *write targets*, so a user passing `--force` for target reasons would
+  silently downgrade a strictly-newer `SKILL.md` and see only the plain `✓` line. So the
+  comparison runs **before** the force check, not instead of it, and the result carries what it
+  overrode: `{ written: true; overwroteNewer?: true; onDiskVersion; bundledVersion }`. `setup.ts`
+  prints one line for that case — *`⚠ overwrote the installed skill (v<n>) with this install's
+  v<m> because --force was passed`* — so the downgrade is never invisible. Read the file
+  unconditionally; the early return is what `force` skips.
+
 - **`src/server/integrations/api-routes.ts` deliberately passes no `force`.** Line 1008 stays
   `await (deps.installSkill ?? installSkill)()`, so the wizard defaults to `force: false` — same
   doctrine as the absent request-body `homeOverride` (`apply.ts:2060-2064`, `api-routes.ts:151-159`):
@@ -84,8 +94,12 @@ makes false in the safe direction and this fix makes false in the current wordin
   the documented way. The response keeps echoing nothing about the skill, and the seam type stays
   `typeof installSkill`.
 
-- **`installSkill` itself logs the skip, so the surface that cannot repair it still leaves a
-  trace.** On the `newer-on-disk` return, one `console.error` naming both versions and the
+- **`installSkill` itself logs the skip, so the surface that cannot repair it leaves a trace in
+  the log rather than returning silently.** Be precise about who reads it: the wizard path runs
+  inside the sidecar (`src/server/integrations/api-routes.ts:1008`), so this line lands in the
+  sidecar log, which a desktop user will not see. It makes the skip diagnosable after the fact; it
+  does not notify that population, and the PR body must say so rather than claiming coverage.
+  On the `newer-on-disk` return, one `console.error` naming both versions and the
   version-independent remedy — *delete `~/.claude/skills/tandem/SKILL.md` and re-run*. Without it
   the skip is invisible to the wizard route (which echoes nothing) and to the desktop population,
   which is precisely the one that cannot run the CLI remedy: `cliAvailable`'s own rationale
@@ -97,10 +111,15 @@ makes false in the safe direction and this fix makes false in the current wordin
   `⚠` below, which is the half that can name `--force` because the leaf does not know its caller);
   that duplication is the accepted cost of the wizard path getting a trace at all.
 
-- **Return `SkillInstallResult`**: `{ written: true } | { written: false; reason: "newer-on-disk";
-  onDiskVersion: number; bundledVersion: number }` (was `Promise<void>`), so the silent no-op is
-  reportable. `src/cli/setup.ts:178-183` prints `✓ ~/.claude/skills/tandem/SKILL.md` on a write and,
-  otherwise:
+- **Return `SkillInstallResult`**: `{ written: true; overwroteNewer?: true; onDiskVersion?: number;
+  bundledVersion?: number } | { written: false; reason: "newer-on-disk"; onDiskVersion: number;
+  bundledVersion: number }` (was `Promise<void>`), so the silent no-op is reportable.
+  **`SkillInstallResult` is exported as a TYPE from `apply.ts`** — it is the return half of the
+  #1894 seam's contract (`installSkill?: typeof installSkill;`, `src/server/integrations/api-routes.ts:159`)
+  and the retyped spy below annotates with it. The prohibition further down covers **runtime**
+  symbols only: `readSkillVersion` and `BUNDLED_SKILL_VERSION` stay module-private.
+  `src/cli/setup.ts:178-183` prints `✓ ~/.claude/skills/tandem/SKILL.md` on a plain write, the
+  `overwroteNewer` line above when `--force` overrode a newer stamp, and otherwise:
 
   > `⚠ kept the installed skill (v<n> on disk is newer than this install's v<m>) — re-run with
   > --force to overwrite it, or delete ~/.claude/skills/tandem/SKILL.md and re-run`
@@ -141,8 +160,21 @@ makes false in the safe direction and this fix makes false in the current wordin
     comparison never fires there. No edit.
 
 - **`tests/skill-instruction-contract.test.ts`**: one new spec pinning a single object literal
-  `{ version: <the number already pinned in this file>, bodyHash: "<sha256 of the body, first 12
-  hex>" }` — `createHash("sha256")` over the text **after** the closing `---` of the frontmatter,
+  `{ version: 15, bodyHash: "<sha256 of the body, first 12 hex>" }` — **15** is the number this
+  file already pins at `tests/skill-instruction-contract.test.ts:80`
+  (`expect(skill).toMatch(/^version:\s*15$/m)`), matching `skills/tandem/SKILL.md:3`. (The sweep
+  doc's environment table still records 14; J1 landed the bump. Read the file, not the table.)
+
+  **This makes the group NOT file-disjoint from group C, and that must be handled before landing.**
+  The new `{version, bodyHash}` literal shares `tests/skill-instruction-contract.test.ts` with every
+  skill-bumping group, and the wave-3 table puts F-doctor and C in the same wave on the stated
+  precondition that groups in one wave are file-disjoint
+  (`docs/plans/2026-09-06-open-issues-sweep.md:67`, and C's row carries a "skill bump"). So:
+  **F-doctor lands before C**, and C's spec and ledger row are told to update the `bodyHash`
+  literal alongside the `version` literal in the same commit. Without that instruction C's skill
+  bump hands the suite a red hash with nothing explaining it.
+
+  The hash is `createHash("sha256")` over the text **after** the closing `---` of the frontmatter,
   with `\r\n` normalised to `\n` first (this repo has a documented CRLF-staleness hazard; a
   checkout artefact must not red the suite). Excluding the frontmatter is deliberate: a version
   bump alone then does not churn the hash, so the loud case is precisely "body changed, version
@@ -169,7 +201,11 @@ makes false in the safe direction and this fix makes false in the current wordin
 1. On-disk `version: 999` → the file is **byte-identical** afterwards and the result is
    `{ written: false, reason: "newer-on-disk" }`. The single spec that kills the bare
    `atomicWrite`; assert the bytes, not just the return value, so a fix that computes the verdict
-   and writes anyway still fails.
+   and writes anyway still fails. **Plus the stderr trace:**
+   `const errSpy = vi.spyOn(console, "error").mockImplementation(() => {})`, and the captured text
+   names both version numbers and `~/.claude/skills/tandem/SKILL.md`. Nothing else asserts
+   `installSkill`'s own log, so without this the trace can be dropped in review or by `/simplify`
+   with the suite green — which is the silent-skip condition the Fix added it to close.
 2. On-disk `version: 1` → overwritten with `SKILL_CONTENT`, `{ written: true }`.
 3. **On-disk equal to `BUNDLED_SKILL_VERSION` → IS rewritten**, `{ written: true }` — the `>`,
    not `>=`, boundary. Write a mangled body carrying the current `version:` line and assert the
@@ -183,8 +219,11 @@ makes false in the safe direction and this fix makes false in the current wordin
    `readSkillVersion` the precedent already uses (`tests/server/integrations/refresh-skill.test.ts:69`)
    and run it over `SKILL_CONTENT`, which *is* exported (`src/cli/skill-content.ts:20`). The
    mangled body is then `` `---\nversion: ${n}\n---\nmangled\n` `` for that `n`.
-4. On-disk `version: 999` **with `{ force: true }`** → overwritten, `{ written: true }`. Kills a
-   comparison with no escape hatch, which would make a tampered stamp permanently un-repairable.
+4. On-disk `version: 999` **with `{ force: true }`** → overwritten, and the result is
+   `{ written: true, overwroteNewer: true, onDiskVersion: 999, bundledVersion: <n> }`. Kills a
+   comparison with no escape hatch (which would make a tampered stamp permanently un-repairable)
+   **and** kills a `force` that short-circuits the read, which is what would make the `--force`
+   overload silently downgrade a newer skill for a user who passed the flag for target reasons.
 5. No file → written (kills copying the refresher's ENOENT early-return into the create path).
 6. The existing "overwrites existing file on re-run" spec (`"old content"`, no frontmatter →
    version 0) must stay green — an unversioned file is still upgraded.
@@ -193,7 +232,10 @@ makes false in the safe direction and this fix makes false in the current wordin
    the kept-skill line (kills a caller that dereferences the result unguarded), and assert that
    line names `--force` rather than "upgrade". Add a spec that `runSetup({ apply: true, force:
    true })` calls the `installSkill` mock with `{ force: true }` — the only thing that pins the
-   flag is actually threaded.
+   flag is actually threaded. **And a spec where the mock resolves
+   `{ written: true, overwroteNewer: true, onDiskVersion: 999, bundledVersion: 15 }` → setup prints
+   the overwrote-newer line naming both numbers**, which is what keeps a `--force` passed for
+   target reasons from silently downgrading the skill behind a plain `✓`.
 8. `tests/server/integrations/api-routes.test.ts`: the retyped spy, per the Fix. No behaviour
    change asserted — the route still echoes nothing about the skill.
 9. `tests/skill-instruction-contract.test.ts`: the hash spec itself. Mutation check for the PR
@@ -203,9 +245,12 @@ makes false in the safe direction and this fix makes false in the current wordin
 ## Done when
 
 An older `setup --apply` cannot downgrade a newer installed skill and says so with a remedy that
-works; **a skip leaves a stderr trace from `installSkill` itself, so the wizard/desktop path is
-not silent**; a re-run at the same version still rewrites the file; `--force` overwrites a newer
-stamp; one `atomicWrite` site remains in `installSkill` and
+works; **a skip leaves a trace in the server log rather than returning silently** — the honest
+limit, which the PR body must also carry: the wizard path runs inside the sidecar
+(`src/server/integrations/api-routes.ts:1008`), so that `console.error` reaches the sidecar log,
+not the desktop user, and the route still echoes nothing about the skill; a re-run at the same
+version still rewrites the file; `--force` overwrites a newer stamp **and says which version it
+overwrote**; one `atomicWrite` site remains in `installSkill` and
 `tests/server/document-write-rearm.test.ts`'s census row is untouched; a body-only skill edit reds
 `skill-instruction-contract`; item 2's measurement is in the PR body with its citations;
 `npm run typecheck:tests` green (the return-type change touches two mock sites); typecheck + the
@@ -283,6 +328,43 @@ to `refreshExistingSkillIfStale`. A `force` parameter on the apply HTTP route. #
   `SKILL_CONTENT` (`src/cli/skill-content.ts:20`) with a local `readSkillVersion` copy, as
   `tests/server/integrations/refresh-skill.test.ts:69` already does, and explicitly forbids
   exporting new symbols from `apply.ts` for it.
+
+**Not adopted**
+
+- None.
+
+## Review corrections (round 3)
+
+**Adopted**
+
+- **BLOCKING** *The `bodyHash` spec lands in `tests/skill-instruction-contract.test.ts` — the file
+  group C must also edit in the same wave — and the version literal it derives from is already 15,
+  not the 14 the sweep doc records.* The Fix now names the concrete value (15, at
+  `tests/skill-instruction-contract.test.ts:80`, matching `skills/tandem/SKILL.md:3`), notes that
+  the sweep doc's environment table is stale because J1 landed the bump, and states plainly that
+  this group is **not** file-disjoint from C against
+  `docs/plans/2026-09-06-open-issues-sweep.md:67`: F-doctor lands before C, and C's spec and ledger
+  row must be told to update the `bodyHash` literal alongside the `version` literal in the same
+  commit.
+- *`--force` can silently downgrade a strictly-newer installed skill: the flag is already parsed
+  for `detectTargets` (target-refusal semantics, `src/cli/setup.ts:116`), so a user passing it for
+  that reason gets the plain `✓` with no sign a newer `SKILL.md` was overwritten.* The comparison
+  now runs **before** the force check; the result carries
+  `{ written: true, overwroteNewer: true, onDiskVersion, bundledVersion }`; `setup.ts` prints a
+  line naming both versions; test 4 asserts the fields and test 7 gains the printed-line spec.
+- *Done-when claimed the stderr trace makes "the wizard/desktop path not silent", which overstates
+  what the desktop population sees — the wizard route runs in the sidecar and its stderr goes to
+  the sidecar log.* Both the Fix bullet and Done-when are reworded to the checkable property (a
+  skip leaves a trace in the server log rather than returning silently), with the honest limit
+  stated and required in the PR body.
+- *The spec forbids exporting new symbols from `apply.ts` for a test while its own retype requires
+  the `SkillInstallResult` type in `tests/server/integrations/api-routes.test.ts`.* The return-type
+  bullet now says `SkillInstallResult` is exported as a **type** (it is the return half of the
+  #1894 seam contract) and scopes the prohibition to runtime symbols — `readSkillVersion` and
+  `BUNDLED_SKILL_VERSION`.
+- *Done-when requires a stderr trace on the skip and no spec asserted it, so it could be dropped
+  in review or by `/simplify` with the suite green.* Test 1 now spies `console.error` and asserts
+  the captured text names both version numbers and `~/.claude/skills/tandem/SKILL.md`.
 
 **Not adopted**
 

--- a/docs/reviews/2026-09-02-v1-review/tracks/specs/F-doctor-1790.md
+++ b/docs/reviews/2026-09-02-v1-review/tracks/specs/F-doctor-1790.md
@@ -1,0 +1,115 @@
+# F-doctor — #1790 skill and plugin version skew
+
+Branch `fix/doctor-and-skill-version-skew-1806`. Closes #1790. Ledger:
+`docs/reviews/2026-09-02-v1-review/areas/upgrade-path.md:17-18` and
+`areas/skill-plugin.md:21`. The `[ran]` experiment for the skill-content row (per-tag `curl` +
+md5, `55d1e8ea` → `68fa0ce0` at unchanged `version: 4`) becomes the hash spec below. **Land last
+of the four** — item 4 of this issue is #1811's subject and is fixed there.
+
+## Problem
+
+Four items in the body; **two are live, one is already closed on master, one belongs to #1811.**
+
+1. **Live.** `installSkill` (`src/server/integrations/apply.ts`) is `mkdir` + a bare
+   `atomicWrite(SKILL_CONTENT, skillPath)` with no comparison. Its sibling
+   `refreshExistingSkillIfStale` compares `readSkillVersion(on-disk)` against
+   `BUNDLED_SKILL_VERSION` and writes only when the bundle is newer. So an **older** npm
+   `tandem setup --apply` — which doctor prescribes for several conditions — silently downgrades
+   a newer installed skill, and overwrites a hand-edited one. This is not theoretical: the
+   `deps.installSkill` seam added by #1894 exists because the api-routes suite had downgraded the
+   operator's v15 install to v14 three times in one night.
+2. **Already closed on master, measured, not re-fixed.** `.claude-plugin/plugin.json` is at
+   `0.25.0` = `package.json`'s `0.25.0`; `.claude/skills/release/SKILL.md` §"The six version
+   surfaces" item 2 already enumerates all **five** plugin.json values including the four
+   `tandem-editor@<version>` npx pins; `tests/plugin-manifest.test.ts:26` pins
+   `plugin.version === pkg.version` and `:55-56` / `:110` derive every npx spec from `pkg.version`;
+   `tests/plugin/plugin-version-pin.test.ts` is the dedicated drift guard. The release step and
+   the wiring test the track file asks for both exist — **add nothing.** What remains is the
+   *user's installed copy*: a plugin installed at 0.24.1 keeps pinning 0.24.1 until reinstalled,
+   which no repo-side guard can move. Recorded under `bryan`, not fixed here.
+3. **Live.** `tests/skill-instruction-contract.test.ts` pins the frontmatter `version` number
+   only, so a content-only edit at an unchanged version is invisible — the exact miss that made
+   v0.20.0/v0.20.1 never reach upgraders (the refresh gate is version-keyed).
+4. Double toolset — **#1811**, not here.
+
+`docs/cli.md:19` also states the skill is "idempotent — refreshed on every run", which item 1
+makes false in the safe direction and this fix makes false in the current wording.
+
+## Fix
+
+- **`src/server/integrations/apply.ts`, `installSkill`.** Model: `refreshExistingSkillIfStale`,
+  reusing its `readSkillVersion` and `BUNDLED_SKILL_VERSION` — one comparison rule, not a second
+  copy. Keep `assertPathSafe` and `mkdir` exactly as they are. Between `mkdir` and the write:
+  `readFile(skillPath, "utf8")`; if it resolves and
+  `BUNDLED_SKILL_VERSION !== 0 && readSkillVersion(current) >= BUNDLED_SKILL_VERSION`, return
+  without writing. `ENOENT` → write (this is the **create** path — that is the one thing it must
+  not inherit from the refresher, which returns early on a missing file so generic server startup
+  never installs a standalone copy). Any other read error → write, preserving today's behaviour
+  for the consent-bearing installer. `BUNDLED_SKILL_VERSION === 0` → write, again unlike the
+  refresher: an unstamped bundle cannot be compared, and this call site has explicit user consent.
+  Exactly **one** `atomicWrite` call site survives — `tests/docs/config-writer-set-claims.test.ts`
+  derives the accepted-writer set by call-site count, so adding a second would widen #1599's bound.
+- **Return `SkillInstallResult`**: `{ written: true } | { written: false; reason: "newer-on-disk";
+  onDiskVersion: number; bundledVersion: number }` (was `Promise<void>`), so the silent no-op is
+  reportable. `src/cli/setup.ts` prints `✓ ~/.claude/skills/tandem/SKILL.md` on a write and
+  `⚠ kept the installed skill (v<n> on disk is newer than this install's v<m>) — upgrade Tandem
+  to move it` otherwise. Read it defensively (`result?.written === false`): the existing
+  `vi.fn()` mocks in `tests/cli/run-setup-apply.test.ts` resolve `undefined`, and those mocks are
+  updated in the same commit rather than relied on.
+- **`src/server/integrations/api-routes.ts` is unchanged.** It calls
+  `await (deps.installSkill ?? installSkill)()` and ignores the value; the response must keep
+  echoing nothing about the skill, and the `typeof installSkill` seam type follows automatically.
+  **Keep the #1894 seam** — no test may reach the real `~/.claude/skills/tandem/SKILL.md`.
+- **`tests/skill-instruction-contract.test.ts`**: one new spec pinning a single object literal
+  `{ version: <the number already pinned in this file>, bodyHash: "<sha256 of the body, first 12
+  hex>" }` — `createHash("sha256")` over the text **after** the closing `---` of the frontmatter,
+  with `\r\n` normalised to `\n` first (this repo has a documented CRLF-staleness hazard; a
+  checkout artefact must not red the suite). Excluding the frontmatter is deliberate: a version
+  bump alone then does not churn the hash, so the loud case is precisely "body changed, version
+  did not". The failure message names the required move: *bump `version:` in
+  `skills/tandem/SKILL.md` and update both literals together*. **Honest limit, state it in the
+  comment and the PR body:** this forces a deliberate edit at the exact spot that says what to do;
+  it cannot mechanically prove the bump happened, because nothing in the working tree remembers
+  the previous body. It converts a silent miss into a red test, which is what the taken decision
+  asks for.
+- **`skills/tandem/SKILL.md` is NOT edited** (`skill: false` for this group), so its `version`
+  literal does not move and the new hash is computed from HEAD's content.
+- **`docs/cli.md:19`**: replace "(idempotent — refreshed on every run)" with "(installed if
+  absent, and refreshed only when this install's skill is newer — a newer or hand-edited installed
+  skill is kept)". The `CLAUDE.md:273` conflation the issue also names no longer exists at HEAD
+  (`grep -n installSkill CLAUDE.md` is empty) — nothing to change there.
+
+## Tests
+
+`tests/cli/setup.test.ts`'s existing `describe("installSkill")` (scratch `homeOverride` tmpdir —
+**never the real home**):
+
+1. On-disk `version: 999` → the file is **byte-identical** afterwards and the result is
+   `{ written: false, reason: "newer-on-disk" }`. The single spec that kills the bare
+   `atomicWrite`; assert the bytes, not just the return value, so a fix that computes the verdict
+   and writes anyway still fails.
+2. On-disk `version: 1` → overwritten with `SKILL_CONTENT`, `{ written: true }`.
+3. On-disk equal to `BUNDLED_SKILL_VERSION` → not written (the `>=`, not `>`, boundary).
+4. No file → written (kills copying the refresher's ENOENT early-return into the create path).
+5. The existing "overwrites existing file on re-run" spec (`"old content"`, no frontmatter →
+   version 0) must stay green — an unversioned file is still upgraded.
+6. `tests/cli/run-setup-apply.test.ts`: the `installSkill` mock resolves `{ written: true }`; add
+   a case where it resolves `{ written: false, … }` and `applySetup` still completes and prints
+   the kept-skill line (kills a caller that dereferences the result unguarded).
+7. `tests/skill-instruction-contract.test.ts`: the hash spec itself. Mutation check for the PR
+   body — appending one line to a scratch copy of the body flips it red while the `version`
+   assertion stays green.
+
+## Done when
+
+An older `setup --apply` cannot downgrade a newer installed skill and says so; one `atomicWrite`
+site remains in `installSkill`; a body-only skill edit reds `skill-instruction-contract`;
+`docs/cli.md` matches the behaviour; item 2's measurement is in the PR body with its citations;
+typecheck + the CLI, plugin and root suites green.
+
+## Not in scope
+
+Moving the plugin's npx pin to `latest` (rejected by `plugin-manifest.test.ts`'s pinned-spec
+assertion and its stale-global rationale) or a doctor check for an *installed* plugin whose pin
+lags the running version — `bryan`. Hashing the bundled content into the frontmatter. Any change
+to `refreshExistingSkillIfStale`. #1790 item 4 (→ #1811).

--- a/docs/reviews/2026-09-02-v1-review/tracks/specs/F-doctor-1790.md
+++ b/docs/reviews/2026-09-02-v1-review/tracks/specs/F-doctor-1790.md
@@ -171,3 +171,18 @@ single-`atomicWrite` constraint; the two named mock sites; the two deliberately-
 references; the `bodyHash` spec — issue item 3 — carrying the outstanding finding's fix in full
 (literal is 15, not the sweep doc's stale 14; this group is not file-disjoint from C, lands first,
 and C updates both literals together).
+
+## Review corrections (post-ship)
+
+- **The wizard route no longer discards the result.** `installSkill()` returned `{ written: false,
+  … }` and `POST /api/integrations/apply` answered 200 with every integration `applied` while
+  nothing anywhere said the skill was left alone — `getSkillRefreshError()` stayed `null` because
+  only the refresher set it. The route now passes the result to `recordSkillInstallOutcome`
+  (`apply.ts`, beside `getSkillRefreshError`), which records `{ code: "newer-on-disk" }` with the
+  same wording and delete-the-file remedy `setup --apply` prints, and clears the record on a write;
+  the route also logs one `console.error` line. **The response shape and the client are
+  unchanged** — a declined skill is not a failed integration, and the client already renders
+  `status.skillRefresh`. Two specs in `tests/server/integrations/api-routes.test.ts` pin it through
+  the existing `installSkill` seam. This is narrower than the `console.error` trace the scope cut
+  removed: that one sat inside `installSkill` and fired on the CLI path too, where `setup --apply`
+  already prints the skip.

--- a/docs/reviews/2026-09-02-v1-review/tracks/specs/F-doctor-1806.md
+++ b/docs/reviews/2026-09-02-v1-review/tracks/specs/F-doctor-1806.md
@@ -127,8 +127,16 @@ port from a `listen(0)` handle, never a literal.
 
 `TANDEM_PORT=<n> tandem doctor` and `TANDEM_MCP_PORT=<n> npm run doctor` probe `<n>` and say so;
 the three specs above are green; **`runDoctor` gains no read of `TANDEM_PORT`/`TANDEM_MCP_PORT` —
-the resolution site stays in `runDoctorCli`** (`grep -n 'TANDEM_PORT\|TANDEM_MCP_PORT'
-src/cli/doctor.ts` returns only `resolveDoctorPortsFromEnv`); typecheck + the CLI suite green.
+the resolution site stays in `runDoctorCli`**; typecheck + the CLI suite green.
+
+**The criterion is scoped to the READ, not the token**:
+`grep -n 'process\.env\.TANDEM_PORT\|process\.env\.TANDEM_MCP_PORT' src/cli/doctor.ts` returns
+only the two lines inside `resolveDoctorPortsFromEnv`. A bare-token grep is already false at HEAD
+— `src/cli/doctor.ts:2873` is the `RunDoctorOptions` docblock ("the `/api/diagnostics` route on a
+`TANDEM_PORT`-overridden server") — and #1807 lands two more mentions on this same branch, inside
+arm 4's user-facing `portFix` strings ("or unset `TANDEM_MCP_PORT` and restart Tandem"). A
+criterion that reads red on correct code invites a reviewer to delete the env-var name from a
+remedy that needs it.
 
 **Not** "`runDoctor` reads no environment": it already reads `HOME`, `USERPROFILE` and
 `TANDEM_APP_DATA_DIR`, and its `homeOverride` docblock (`src/cli/doctor.ts:2860-2862`) says
@@ -190,6 +198,21 @@ fallback is silent, and the probed port is printed — see `assumptions`); `TAND
   `TANDEM_PORT`/`TANDEM_MCP_PORT`, the resolution site stays in `runDoctorCli` — plus a paragraph
   naming what the header contract actually says. The same false claim in "Not changed, on
   purpose" is corrected in place.
+
+**Not adopted**
+
+- None.
+
+## Review corrections (round 3)
+
+**Adopted**
+
+- *The Done-when grep criterion is already false at HEAD, and #1807 falsifies it a second time on
+  this branch* (raised twice). The criterion is now scoped to the read —
+  `grep -n 'process\.env\.TANDEM_PORT\|process\.env\.TANDEM_MCP_PORT' src/cli/doctor.ts` returns
+  only the two lines inside `resolveDoctorPortsFromEnv` — with both falsifying sites named
+  (`src/cli/doctor.ts:2873`'s docblock, and #1807's arm-4 `portFix` strings), so a reviewer does
+  not "fix" a red criterion by deleting the env-var name from a user-facing remedy.
 
 **Not adopted**
 

--- a/docs/reviews/2026-09-02-v1-review/tracks/specs/F-doctor-1806.md
+++ b/docs/reviews/2026-09-02-v1-review/tracks/specs/F-doctor-1806.md
@@ -48,10 +48,13 @@ it.
 
 Not changed, on purpose:
 
-- **`runDoctor` does not read the environment.** Its header contract ("Performs NO `process.argv`
-  reads… Embedders that know their live ports pass them via `opts`") stays true, and one
-  resolution site means the server embedder cannot end up with the CLI's answer layered under its
-  own. `vitePort`/`homeOverride` are untouched.
+- **`runDoctor` does not read the two PORT variables.** Not "reads no environment" — it already
+  reads `HOME`/`USERPROFILE` (`src/cli/doctor.ts:1106`, `:1970`) and `TANDEM_APP_DATA_DIR`, and
+  the `homeOverride` docblock (`:2860-2862`) records that `checkUserMcpConfig` deliberately keeps
+  doing so. Its header contract is narrower than that: "Performs NO `process.argv` reads and NEVER
+  calls `process.exit`" (`:2871-2874`), plus "Embedders that know their live ports pass them via
+  `opts`". One port-resolution site means the server embedder cannot end up with the CLI's answer
+  layered under its own. `vitePort`/`homeOverride` are untouched.
 - **`src/server/index.ts` is not refactored onto the shared helper.** Its lenient `parseInt` is
   the behaviour being mirrored, and rewriting the boot path is risk with no issue behind it.
 - No new check, no new message. `checkPorts` already names the ports.
@@ -71,8 +74,14 @@ directly. The reads are read-only, but leaving them pointed at the operator's re
 specs' outcomes depend on machine state — the rule this group carries from #1894. So the
 describe's `beforeEach` does `mkdtempSync` plus `vi.stubEnv("HOME", dir)` **and**
 `vi.stubEnv("USERPROFILE", dir)` (both — `homedir()` reads `USERPROFILE` on Windows, which is the
-platform this wave runs on), exactly as the `checkUserMcpConfig wiring` describe does; `afterEach`
-does `vi.unstubAllEnvs()` and `rmSync`. The only live variable in these specs is the port.
+platform this wave runs on); `afterEach` does `vi.unstubAllEnvs()` and `rmSync`. The only live
+variable in these specs is the port.
+
+**Do not copy the `checkUserMcpConfig wiring` describe's `beforeEach` verbatim** — it stubs `HOME`
+alone (`tests/cli/doctor.test.ts:2026-2031`), which is safe *there* only because
+`checkUserMcpConfig` reads `process.env.HOME || process.env.USERPROFILE` itself
+(`src/cli/doctor.ts:1107`) and never falls through to `homedir()`. These specs run the whole
+doctor, so the both-variables rule above is new, not inherited.
 
 1. **Resolver table** on the exported `resolveDoctorPortsFromEnv({ TANDEM_PORT: …, TANDEM_MCP_PORT: … })`:
    `"4918"` → 4918; unset → 3478/3479; `""` → default (the `||` arm, which is why the server's
@@ -91,9 +100,25 @@ does `vi.unstubAllEnvs()` and `rmSync`. The only live variable in these specs is
    diagnosable cause: ephemeral ports such as 33478, 43478, 53478, 63478 and 34780–34789 all
    contain that digit string, and the harness cannot choose which one the kernel hands out.
    Close the listener in `afterEach`.
-3. Same shape for `TANDEM_MCP_PORT` with a listener bound on it, asserting the message names it
-   under the same word-boundary rule — kills a fix that wires only `wsPort` (the two are separate
-   `??` reads).
+3. Same shape for `TANDEM_MCP_PORT` with a listener bound on it, asserting the message names the
+   probed port under the same word-boundary rule — kills a fix that wires only `wsPort` (the two
+   are separate `??` reads).
+
+   **Its negative is `not.toMatch(/\b3479\b/)`, and `3478` is EXPECTED to appear.** With only the
+   MCP port listening, `checkPorts` takes its partial branch and emits
+   `` `Partial: port ${wsPort} down, port ${mcpPort} up` `` (`src/cli/doctor.ts:2081-2084`) —
+   `wsPort` is still the default there because only `TANDEM_MCP_PORT` was stubbed. Copying test
+   2's `not.toMatch(/\b3478\b/)` across therefore fails on correct code. Assert the absence of the
+   *default MCP* port, which is the value this spec discriminates.
+
+**The MCP-port listener must be an `http.createServer` that answers, not a bare `net` server.**
+`runDoctor` runs `checkHealth` whenever the MCP probe succeeds (`src/cli/doctor.ts:2953-2959`) and
+`httpGet` defaults to `timeoutMs = 3000` (`:2219`); a socket that accepts and never replies burns
+that full 3 s inside vitest's 5 s default, on top of the ~335-`statSync` PATH walk `cliAvailable`
+performs on a machine without the CLI (`:1258-1262`). A four-line
+`http.createServer((_, res) => { res.statusCode = 404; res.end(); })` answers immediately and
+still fails the health check, which is all the spec needs. Give **both** wiring specs an explicit
+`20_000` ms timeout anyway, with that reason in a comment — test 2 pays the PATH walk too.
 
 Both wiring tests must avoid the reserved harness ports and 3478/3479 by construction: take the
 port from a `listen(0)` handle, never a literal.
@@ -101,8 +126,14 @@ port from a `listen(0)` handle, never a literal.
 ## Done when
 
 `TANDEM_PORT=<n> tandem doctor` and `TANDEM_MCP_PORT=<n> npm run doctor` probe `<n>` and say so;
-the three specs above are green; `runDoctor`'s no-env contract is intact; typecheck + the CLI
-suite green.
+the three specs above are green; **`runDoctor` gains no read of `TANDEM_PORT`/`TANDEM_MCP_PORT` —
+the resolution site stays in `runDoctorCli`** (`grep -n 'TANDEM_PORT\|TANDEM_MCP_PORT'
+src/cli/doctor.ts` returns only `resolveDoctorPortsFromEnv`); typecheck + the CLI suite green.
+
+**Not** "`runDoctor` reads no environment": it already reads `HOME`, `USERPROFILE` and
+`TANDEM_APP_DATA_DIR`, and its `homeOverride` docblock (`src/cli/doctor.ts:2860-2862`) says
+`checkUserMcpConfig` deliberately keeps doing so. The header contract that must stay true is the
+one it actually states — no `process.argv` reads, no `process.exit` (`:2871-2874`).
 
 ## Not in scope
 
@@ -131,6 +162,34 @@ fallback is silent, and the probed port is printed — see `assumptions`); `TAND
   (`homedir()` reads `USERPROFILE` on Windows), `vi.unstubAllEnvs()` in `afterEach` — matching the
   existing `checkUserMcpConfig wiring` describe, and closing the machine-dependence the #1894 rule
   exists for.
+
+**Not adopted**
+
+- None.
+
+## Review corrections (round 2)
+
+**Adopted**
+
+- *Test 3's negative, copied from test 2, fails on correct code.* With only the MCP port bound,
+  `checkPorts` takes its partial branch and names `wsPort` — still the default 3478
+  (`src/cli/doctor.ts:2081-2084`). Test 3 now spells its own negative:
+  `not.toMatch(/\b3479\b/)`, with a sentence saying 3478 is expected to appear.
+- *The wiring specs' bare `net` listener makes doctor run `checkHealth` against a socket that
+  never answers — a 3 s stall inside vitest's 5 s default.* The MCP-port spec now specifies a
+  four-line `http.createServer` returning 404, and both wiring specs carry an explicit `20_000` ms
+  timeout with the PATH-walk reason in a comment (`httpGet` default `timeoutMs = 3000` at
+  `src/cli/doctor.ts:2219`; `cliAvailable`'s ~335 `statSync` calls at `:1258-1262`).
+- *The scratch-home rule cited a precedent that does not exist.* `tests/cli/doctor.test.ts:2026-2031`
+  stubs `HOME` only. The "exactly as … does" clause is gone; the paragraph now states the
+  both-variables rule as **new**, and says why the existing describe is safe with one stub
+  (`checkUserMcpConfig` reads `HOME || USERPROFILE` itself at `src/cli/doctor.ts:1107`) while
+  these specs, which run the whole doctor, are not.
+- *Done-when asserted a `runDoctor` no-env property that no test checks and the code does not
+  have.* Replaced with the checkable form — `runDoctor` gains no read of
+  `TANDEM_PORT`/`TANDEM_MCP_PORT`, the resolution site stays in `runDoctorCli` — plus a paragraph
+  naming what the header contract actually says. The same false claim in "Not changed, on
+  purpose" is corrected in place.
 
 **Not adopted**
 

--- a/docs/reviews/2026-09-02-v1-review/tracks/specs/F-doctor-1806.md
+++ b/docs/reviews/2026-09-02-v1-review/tracks/specs/F-doctor-1806.md
@@ -115,3 +115,17 @@ green.
 
 Everything the issue names: the two env vars reach `runDoctor` through the CLI wrapper, and the
 probed port is printed. No finding was outstanding against this spec.
+
+## Review corrections (post-ship)
+
+- **The stdio MCP server now carries the live ports too.** This spec's Problem section credited
+  the `/api/diagnostics` embedder with threading live ports, and the HTTP path does — but
+  `startMcpServerStdio` built its server with `{ version, transport: "stdio" }` and nothing else,
+  so `tandem_diagnostics` in stdio mode on a moved install probed the defaults, reported them not
+  listening and prescribed a second instance. `index.ts` now passes the `{ wsPort, mcpPort }` it
+  already resolved at `:98-99` (one resolution site, as this spec requires — nothing re-parses
+  env), and `startMcpServerStdio` gains an optional `transport` seam so
+  `tests/server/mcp-stdio-ports.test.ts` can drive `tandem_diagnostics` over an
+  `InMemoryTransport` with `runDoctor` mocked at the module boundary and pin the exact
+  `{ wsPort, mcpPort }` the collector receives. In stdio mode nothing listens on the MCP port, so
+  its probe still reads "not listening" — but it now names the port the user actually set.

--- a/docs/reviews/2026-09-02-v1-review/tracks/specs/F-doctor-1806.md
+++ b/docs/reviews/2026-09-02-v1-review/tracks/specs/F-doctor-1806.md
@@ -1,0 +1,85 @@
+# F-doctor — #1806 `tandem doctor` ignores `TANDEM_PORT` / `TANDEM_MCP_PORT`
+
+Branch `fix/doctor-and-skill-version-skew-1806`. Closes #1806. Ledger:
+`docs/reviews/2026-09-02-v1-review/areas/shared-cli.md:18`. No experiment — the row is `[read]`;
+the wiring test below is the experiment. **First of four; #1807 threads the port this fix
+resolves, so land it first.**
+
+## Problem
+
+`runDoctorCli` (`src/cli/doctor.ts`, the `report = await runDoctor();` call inside its `try`)
+calls `runDoctor()` with no options, while `RunDoctorOptions` already carries `wsPort`/`mcpPort`
+and `runDoctor` resolves them as `opts.wsPort ?? DEFAULT_WS_PORT`. Nothing in the CLI path ever
+supplies them, so a user who moved the server with the documented `TANDEM_PORT` /
+`TANDEM_MCP_PORT` (`docs/configuration.md:13-14`, honoured at `src/server/index.ts:98-99`) gets
+`Ports 3478 + 3479 not listening — server not running` plus a remedy that starts a **second**
+instance on the defaults — into #1758's lock-then-`freePort` sequence. `scripts/doctor.mjs`
+(`npm run doctor`) routes through the same wrapper and has the same hole. The
+`/api/diagnostics` embedder does **not** — it already threads live ports
+(`src/server/mcp/routes/diagnostics.ts:47-49`), which is why this only ever bit the CLI.
+
+The issue's second half ("print the ports doctor probed") is **already satisfied**: all three
+branches of `checkPorts` interpolate `wsPort`/`mcpPort` into their message. Pin it, don't rewrite
+it.
+
+## Fix
+
+`src/cli/doctor.ts` only. Two additions, both in the printer half of the file:
+
+- A module-private `envPort(raw: string | undefined, fallback: number): number` that **mirrors
+  `src/server/index.ts:98-99` deliberately**: `parseInt(raw || String(fallback), 10)`, then
+  `Number.isInteger(n) && n >= 1 && n <= 65535 ? n : fallback`. `parseInt`, not `Number` and not
+  `backend-ports.ts`'s `/^\d{1,5}$/` — the point is to probe **where the server actually binds**,
+  and the server's `parseInt` binds `4918abc` on 4918. Diverging into a stricter parser would
+  re-create the false "not running" for exactly the inputs the server accepts. The range/NaN
+  guard covers only what the server would fail to bind at all.
+- `resolveDoctorPortsFromEnv(env: NodeJS.ProcessEnv = process.env): { wsPort: number; mcpPort: number }`,
+  **exported** (unit-testable, and the name says where it reads from), returning
+  `{ wsPort: envPort(env.TANDEM_PORT, DEFAULT_WS_PORT), mcpPort: envPort(env.TANDEM_MCP_PORT, DEFAULT_MCP_PORT) }`.
+  `runDoctorCli` calls `runDoctor(resolveDoctorPortsFromEnv())`.
+
+Not changed, on purpose:
+
+- **`runDoctor` does not read the environment.** Its header contract ("Performs NO `process.argv`
+  reads… Embedders that know their live ports pass them via `opts`") stays true, and one
+  resolution site means the server embedder cannot end up with the CLI's answer layered under its
+  own. `vitePort`/`homeOverride` are untouched.
+- **`src/server/index.ts` is not refactored onto the shared helper.** Its lenient `parseInt` is
+  the behaviour being mirrored, and rewriting the boot path is risk with no issue behind it.
+- No new check, no new message. `checkPorts` already names the ports.
+
+Rules that bite: Critical Rule 3 does not apply here (`runDoctorCli`'s stdout is the documented
+CLI surface — see its header). No Y.Doc, no Y.Map, no testid, no `/api` route, no gated tool.
+
+## Tests
+
+`tests/cli/doctor.test.ts`, in a new `describe`:
+
+1. **Resolver table** on the exported `resolveDoctorPortsFromEnv({ TANDEM_PORT: …, TANDEM_MCP_PORT: … })`:
+   `"4918"` → 4918; unset → 3478/3479; `""` → default (the `||` arm, which is why the server's
+   spelling matters); `"4918abc"` → **4918**, not the default — kills a strict-regex resolver that
+   would still misreport a server the real `parseInt` bound; `"abc"` → default; `"0"` and
+   `"70000"` → default.
+2. **Wiring** — the discriminating one, because #1806 *is* a resolver-exists-but-is-not-called
+   bug and a table test alone passes on the broken code. Bind a real `net` server on an ephemeral
+   port, `vi.stubEnv("TANDEM_PORT", String(port))`, `vi.spyOn(process.stdout, "write")`, run
+   `await runDoctorCli({ json: true })`, `JSON.parse` the captured document, and assert the
+   `ports` result's `message` contains that port number and does **not** contain `3478`. Close the
+   listener in `afterEach`; `vi.unstubAllEnvs()`.
+3. Same shape for `TANDEM_MCP_PORT` with a listener bound on it, asserting the message names it —
+   kills a fix that wires only `wsPort` (the two are separate `??` reads).
+
+Both wiring tests must avoid the reserved harness ports and 3478/3479 by construction: take the
+port from a `listen(0)` handle, never a literal.
+
+## Done when
+
+`TANDEM_PORT=<n> tandem doctor` and `TANDEM_MCP_PORT=<n> npm run doctor` probe `<n>` and say so;
+the three specs above are green; `runDoctor`'s no-env contract is intact; typecheck + the CLI
+suite green.
+
+## Not in scope
+
+`src/server/index.ts`'s parse; a doctor check that *reports* an unparseable `TANDEM_PORT` (the
+fallback is silent, and the probed port is printed — see `assumptions`); `TANDEM_URL` /
+`TANDEM_BIND_HOST`; #1758's lock sequence.

--- a/docs/reviews/2026-09-02-v1-review/tracks/specs/F-doctor-1806.md
+++ b/docs/reviews/2026-09-02-v1-review/tracks/specs/F-doctor-1806.md
@@ -1,219 +1,117 @@
 # F-doctor — #1806 `tandem doctor` ignores `TANDEM_PORT` / `TANDEM_MCP_PORT`
 
 Branch `fix/doctor-and-skill-version-skew-1806`. Closes #1806. Ledger:
-`docs/reviews/2026-09-02-v1-review/areas/shared-cli.md:18`. No experiment — the row is `[read]`;
-the wiring test below is the experiment. **First of four; #1807 threads the port this fix
-resolves, so land it first.**
+`docs/reviews/2026-09-02-v1-review/areas/shared-cli.md:18`. **First of four; #1807 uses the port
+this fix resolves, so land it first.**
 
 ## Problem
 
-`runDoctorCli` (`src/cli/doctor.ts`, the `report = await runDoctor();` call inside its `try`)
-calls `runDoctor()` with no options, while `RunDoctorOptions` already carries `wsPort`/`mcpPort`
-and `runDoctor` resolves them as `opts.wsPort ?? DEFAULT_WS_PORT`. Nothing in the CLI path ever
-supplies them, so a user who moved the server with the documented `TANDEM_PORT` /
-`TANDEM_MCP_PORT` (`docs/configuration.md:13-14`, honoured at `src/server/index.ts:98-99`) gets
-`Ports 3478 + 3479 not listening — server not running` plus a remedy that starts a **second**
-instance on the defaults — into #1758's lock-then-`freePort` sequence. `scripts/doctor.mjs`
-(`npm run doctor`) routes through the same wrapper and has the same hole. The
-`/api/diagnostics` embedder does **not** — it already threads live ports
-(`src/server/mcp/routes/diagnostics.ts:47-49`), which is why this only ever bit the CLI.
+`runDoctorCli` calls `report = await runDoctor();` with no options (`src/cli/doctor.ts:3005`),
+while `RunDoctorOptions` already carries `wsPort`/`mcpPort` and `runDoctor` resolves them as
+`opts.wsPort ?? DEFAULT_WS_PORT` (`:2877-2878`). Nothing on the CLI path supplies them, so a user
+who moved the server with the documented `TANDEM_PORT` / `TANDEM_MCP_PORT` (`docs/configuration.md:13-14`,
+honoured at `src/server/index.ts:98-99`) gets `Ports 3478 + 3479 not listening — server not
+running` plus a remedy that starts a **second** instance on the defaults. `scripts/doctor.mjs`
+(`npm run doctor`) routes through the same wrapper. The `/api/diagnostics` embedder already
+threads live ports (`src/server/mcp/routes/diagnostics.ts:47-49`), which is why this only bit the
+CLI.
 
-The issue's second half ("print the ports doctor probed") is **already satisfied**: all three
-branches of `checkPorts` interpolate `wsPort`/`mcpPort` into their message. Pin it, don't rewrite
-it.
+The issue's second half ("print the ports doctor probed") is **already satisfied** — all three
+`checkPorts` branches interpolate `wsPort`/`mcpPort`. Pin it, don't rewrite it.
 
 ## Fix
 
-`src/cli/doctor.ts` only. Two additions, both in the printer half of the file:
+`src/cli/doctor.ts` only, both additions in the printer half:
 
-- A module-private `envPort(raw: string | undefined, fallback: number): number` that **mirrors
+- Module-private `envPort(raw: string | undefined, fallback: number): number` that **mirrors
   `src/server/index.ts:98-99` deliberately**: `parseInt(raw || String(fallback), 10)`, then
   `Number.isInteger(n) && n >= 1 && n <= 65535 ? n : fallback`. `parseInt`, not `Number` and not
   `backend-ports.ts`'s `/^\d{1,5}$/` — the point is to probe **where the server actually binds**,
-  and the server's `parseInt` binds `4918abc` on 4918. Diverging into a stricter parser would
-  re-create the false "not running" for exactly the inputs the server accepts.
+  and the server's `parseInt` binds `4918abc` on 4918. A stricter parser would re-create the false
+  "not running" for exactly the inputs the server accepts.
 
-  **The `1..65535` clamp is a probe-side decision, not a mirror of the server, and `0` is the
-  case that proves it.** `src/server/index.ts:98` is a bare `parseInt` with no guard, and
-  `listen(0)` binds successfully on an OS-chosen ephemeral port — so `TANDEM_PORT=0` is not
-  "what the server would fail to bind". It is *undiagnosable from outside the process*: doctor
-  cannot know which port the kernel handed out, so neither `0` nor the default is a correct
-  probe. The clamp picks the default because that is the answer whose message (`3478 not
-  listening`) is at least a shape the user recognises. Say this in the code comment rather than
-  claiming the guard only covers unbindable input.
+  **The `1..65535` clamp is a probe-side decision, not a mirror of the server.** `listen(0)` binds
+  an OS-chosen ephemeral port, so `TANDEM_PORT=0` is not "input the server would reject" — it is
+  *undiagnosable from outside the process*. The clamp picks the default because `3478 not
+  listening` is at least a shape the user recognises. Say that in the code comment.
 - `resolveDoctorPortsFromEnv(env: NodeJS.ProcessEnv = process.env): { wsPort: number; mcpPort: number }`,
-  **exported** (unit-testable, and the name says where it reads from), returning
-  `{ wsPort: envPort(env.TANDEM_PORT, DEFAULT_WS_PORT), mcpPort: envPort(env.TANDEM_MCP_PORT, DEFAULT_MCP_PORT) }`.
-  `runDoctorCli` calls `runDoctor(resolveDoctorPortsFromEnv())`.
+  **exported**, returning `{ wsPort: envPort(env.TANDEM_PORT, DEFAULT_WS_PORT), mcpPort:
+  envPort(env.TANDEM_MCP_PORT, DEFAULT_MCP_PORT) }`. `runDoctorCli` calls
+  `runDoctor(resolveDoctorPortsFromEnv())`.
 
-Not changed, on purpose:
+Not changed: `runDoctor` gains no read of the two variables (one resolution site, so the server
+embedder cannot end up with the CLI's answer layered under its own); `src/server/index.ts` is not
+refactored onto the helper; no new check and no new message.
 
-- **`runDoctor` does not read the two PORT variables.** Not "reads no environment" — it already
-  reads `HOME`/`USERPROFILE` (`src/cli/doctor.ts:1106`, `:1970`) and `TANDEM_APP_DATA_DIR`, and
-  the `homeOverride` docblock (`:2860-2862`) records that `checkUserMcpConfig` deliberately keeps
-  doing so. Its header contract is narrower than that: "Performs NO `process.argv` reads and NEVER
-  calls `process.exit`" (`:2871-2874`), plus "Embedders that know their live ports pass them via
-  `opts`". One port-resolution site means the server embedder cannot end up with the CLI's answer
-  layered under its own. `vitePort`/`homeOverride` are untouched.
-- **`src/server/index.ts` is not refactored onto the shared helper.** Its lenient `parseInt` is
-  the behaviour being mirrored, and rewriting the boot path is risk with no issue behind it.
-- No new check, no new message. `checkPorts` already names the ports.
-
-Rules that bite: Critical Rule 3 does not apply here (`runDoctorCli`'s stdout is the documented
-CLI surface — see its header). No Y.Doc, no Y.Map, no testid, no `/api` route, no gated tool.
+Rules that bite: Critical Rule 3 does not apply (`runDoctorCli`'s stdout is the documented CLI
+surface — see its header at `:2993-2996`). No Y.Doc, no Y.Map, no testid, no `/api` route.
 
 ## Tests
 
-`tests/cli/doctor.test.ts`, in a new `describe`.
+`tests/cli/doctor.test.ts`, one new `describe`.
 
-**The new describe stubs a scratch home, not just the port.** `RunDoctorCliOptions` is `{ json?:
-boolean }` (`src/cli/doctor.ts:2974-2976`) and `runDoctorCli` calls `runDoctor()` with no opts
-(`:3005`), so there is no `homeOverride` seam on this path: tests 2 and 3 run the *whole* doctor,
-including `checkUserMcpConfig` and `checkTandemPlugin`, which read `HOME`/`USERPROFILE`
-directly. The reads are read-only, but leaving them pointed at the operator's real home makes the
-specs' outcomes depend on machine state — the rule this group carries from #1894. So the
-describe's `beforeEach` does `mkdtempSync` plus `vi.stubEnv("HOME", dir)` **and**
-`vi.stubEnv("USERPROFILE", dir)` (both — `homedir()` reads `USERPROFILE` on Windows, which is the
-platform this wave runs on); `afterEach` does `vi.unstubAllEnvs()` and `rmSync`. The only live
-variable in these specs is the port.
+**Its `beforeEach` stubs a scratch home, not just the port.** `runDoctorCli` has no `homeOverride`
+seam, so tests 2 and 3 run the *whole* doctor, including `checkUserMcpConfig` and
+`checkTandemPlugin`, which read `HOME`/`USERPROFILE` directly. `mkdtempSync` plus
+`vi.stubEnv("HOME", dir)` **and** `vi.stubEnv("USERPROFILE", dir)` — both, because `homedir()`
+reads `USERPROFILE` on Windows, the platform this wave runs on; `vi.unstubAllEnvs()` + `rmSync` in
+`afterEach`. Do **not** copy the existing `checkUserMcpConfig wiring` describe's `beforeEach`
+(`tests/cli/doctor.test.ts:2026-2031`), which stubs `HOME` alone — safe there only because that
+check reads `HOME || USERPROFILE` itself (`src/cli/doctor.ts:1107`).
 
-**Do not copy the `checkUserMcpConfig wiring` describe's `beforeEach` verbatim** — it stubs `HOME`
-alone (`tests/cli/doctor.test.ts:2026-2031`), which is safe *there* only because
-`checkUserMcpConfig` reads `process.env.HOME || process.env.USERPROFILE` itself
-(`src/cli/doctor.ts:1107`) and never falls through to `homedir()`. These specs run the whole
-doctor, so the both-variables rule above is new, not inherited.
+1. **Resolver table** on `resolveDoctorPortsFromEnv({ … })`: `"4918"` → 4918; unset →
+   3478/3479; `""` → default (the `||` arm, which is why the server's spelling matters);
+   `"4918abc"` → **4918**, not the default — kills a strict-regex resolver; `"abc"` → default;
+   `"0"` and `"70000"` → default (the clamp).
+2. **Wiring** — the discriminating one, because #1806 is a resolver-exists-but-is-not-called bug
+   and a table test alone passes on the broken code. Bind a real listener on an ephemeral port,
+   `vi.stubEnv("TANDEM_PORT", String(port))`, spy `process.stdout.write`, `await
+   runDoctorCli({ json: true })`, `JSON.parse` the captured document, assert on the `ports`
+   result's message: a word-boundary regex built from the probed port must match, and
+   `expect(message).not.toMatch(/\b3478\b/)`. **Word boundaries, never `not.toContain("3478")`** —
+   ephemeral ports 33478/43478/53478/63478 and 34780–34789 all contain that digit string, and the
+   harness cannot choose which one the kernel hands out. Close the listener in `afterEach`.
+3. Same shape for `TANDEM_MCP_PORT` — kills a fix that wires only `wsPort` (two separate `??`
+   reads). **Its negative is `not.toMatch(/\b3479\b/)`, and `3478` is EXPECTED to appear**: with
+   only the MCP port up, `checkPorts` takes its partial branch and names the still-default
+   `wsPort` (`src/cli/doctor.ts:2081-2084`), so copying test 2's negative fails on correct code.
 
-1. **Resolver table** on the exported `resolveDoctorPortsFromEnv({ TANDEM_PORT: …, TANDEM_MCP_PORT: … })`:
-   `"4918"` → 4918; unset → 3478/3479; `""` → default (the `||` arm, which is why the server's
-   spelling matters); `"4918abc"` → **4918**, not the default — kills a strict-regex resolver that
-   would still misreport a server the real `parseInt` bound; `"abc"` → default; `"0"` and
-   `"70000"` → default (the clamp, per the comment above).
-2. **Wiring** — the discriminating one, because #1806 *is* a resolver-exists-but-is-not-called
-   bug and a table test alone passes on the broken code. Bind a real `net` server on an ephemeral
-   port, `vi.stubEnv("TANDEM_PORT", String(port))`, `vi.spyOn(process.stdout, "write")`, run
-   `await runDoctorCli({ json: true })`, `JSON.parse` the captured document, and assert on the
-   `ports` result's `message`.
-
-   **Assert structurally, never by substring exclusion.** `expect(message).toMatch(new
-   RegExp(String.raw`\b${port}\b`))` for the probed port, and `expect(message).not.toMatch(/\b3478\b/)`
-   for the default. A bare `not.toContain("3478")` is an intermittent false red with no
-   diagnosable cause: ephemeral ports such as 33478, 43478, 53478, 63478 and 34780–34789 all
-   contain that digit string, and the harness cannot choose which one the kernel hands out.
-   Close the listener in `afterEach`.
-3. Same shape for `TANDEM_MCP_PORT` with a listener bound on it, asserting the message names the
-   probed port under the same word-boundary rule — kills a fix that wires only `wsPort` (the two
-   are separate `??` reads).
-
-   **Its negative is `not.toMatch(/\b3479\b/)`, and `3478` is EXPECTED to appear.** With only the
-   MCP port listening, `checkPorts` takes its partial branch and emits
-   `` `Partial: port ${wsPort} down, port ${mcpPort} up` `` (`src/cli/doctor.ts:2081-2084`) —
-   `wsPort` is still the default there because only `TANDEM_MCP_PORT` was stubbed. Copying test
-   2's `not.toMatch(/\b3478\b/)` across therefore fails on correct code. Assert the absence of the
-   *default MCP* port, which is the value this spec discriminates.
-
-**The MCP-port listener must be an `http.createServer` that answers, not a bare `net` server.**
-`runDoctor` runs `checkHealth` whenever the MCP probe succeeds (`src/cli/doctor.ts:2953-2959`) and
-`httpGet` defaults to `timeoutMs = 3000` (`:2219`); a socket that accepts and never replies burns
-that full 3 s inside vitest's 5 s default, on top of the ~335-`statSync` PATH walk `cliAvailable`
-performs on a machine without the CLI (`:1258-1262`). A four-line
-`http.createServer((_, res) => { res.statusCode = 404; res.end(); })` answers immediately and
-still fails the health check, which is all the spec needs. Give **both** wiring specs an explicit
-`20_000` ms timeout anyway, with that reason in a comment — test 2 pays the PATH walk too.
-
-Both wiring tests must avoid the reserved harness ports and 3478/3479 by construction: take the
-port from a `listen(0)` handle, never a literal.
+**The MCP-port listener is an `http.createServer` that answers, not a bare `net` server.**
+`runDoctor` runs `checkHealth` whenever the MCP probe succeeds (`:2953-2959`) and `httpGet`
+defaults to `timeoutMs = 3000` (`:2219`); a socket that never replies burns 3 s inside vitest's
+5 s default. Four lines returning 404 answer immediately and still fail the health check. Give
+both wiring specs an explicit `20_000` ms timeout, with the reason in a comment — test 2 also pays
+`cliAvailable`'s ~335-`statSync` PATH walk (`:1258-1262`). Both take their port from a `listen(0)`
+handle, never a literal, so the reserved harness ports and 3478/3479 are avoided by construction.
 
 ## Done when
 
 `TANDEM_PORT=<n> tandem doctor` and `TANDEM_MCP_PORT=<n> npm run doctor` probe `<n>` and say so;
-the three specs above are green; **`runDoctor` gains no read of `TANDEM_PORT`/`TANDEM_MCP_PORT` —
-the resolution site stays in `runDoctorCli`**; typecheck + the CLI suite green.
-
-**The criterion is scoped to the READ, not the token**:
-`grep -n 'process\.env\.TANDEM_PORT\|process\.env\.TANDEM_MCP_PORT' src/cli/doctor.ts` returns
-only the two lines inside `resolveDoctorPortsFromEnv`. A bare-token grep is already false at HEAD
-— `src/cli/doctor.ts:2873` is the `RunDoctorOptions` docblock ("the `/api/diagnostics` route on a
-`TANDEM_PORT`-overridden server") — and #1807 lands two more mentions on this same branch, inside
-arm 4's user-facing `portFix` strings ("or unset `TANDEM_MCP_PORT` and restart Tandem"). A
-criterion that reads red on correct code invites a reviewer to delete the env-var name from a
-remedy that needs it.
-
-**Not** "`runDoctor` reads no environment": it already reads `HOME`, `USERPROFILE` and
-`TANDEM_APP_DATA_DIR`, and its `homeOverride` docblock (`src/cli/doctor.ts:2860-2862`) says
-`checkUserMcpConfig` deliberately keeps doing so. The header contract that must stay true is the
-one it actually states — no `process.argv` reads, no `process.exit` (`:2871-2874`).
+the three specs are green; the resolution site stays in `runDoctorCli`; typecheck + the CLI suite
+green.
 
 ## Not in scope
 
-`src/server/index.ts`'s parse; a doctor check that *reports* an unparseable `TANDEM_PORT` (the
-fallback is silent, and the probed port is printed — see `assumptions`); `TANDEM_URL` /
-`TANDEM_BIND_HOST`; #1758's lock sequence.
+`src/server/index.ts`'s parse; a doctor check that *reports* an unparseable `TANDEM_PORT`;
+`TANDEM_URL` / `TANDEM_BIND_HOST`; #1758's lock sequence.
 
 ## Files touched
 
 `src/cli/doctor.ts`, `tests/cli/doctor.test.ts`.
 
-## Review corrections (round 1)
+## Review corrections (scope cut)
 
-**Adopted**
+**Removed**
 
-- *`0` diverges from the server, which does bind `listen(0)`.* The spec asserted the clamp
-  "covers only what the server would fail to bind at all", which `src/server/index.ts:98`
-  contradicts. The Fix section now states the real reason `0` falls back — an ephemeral port is
-  undiagnosable from outside the process — and requires that reason in the code comment. The
-  table spec keeps `"0"` → default.
-- *The wiring specs' `not.toContain("3478")` is an intermittent false red.* Replaced with
-  word-boundary regexes in both directions (Tests 2 and 3), with the ephemeral-port collision
-  cases named so the assertion is not "simplified" back.
-- *The new describe runs the whole doctor against the real HOME.* Tests now open with an explicit
-  scratch-home rule: `mkdtempSync` plus `vi.stubEnv` on **both** `HOME` and `USERPROFILE`
-  (`homedir()` reads `USERPROFILE` on Windows), `vi.unstubAllEnvs()` in `afterEach` — matching the
-  existing `checkUserMcpConfig wiring` describe, and closing the machine-dependence the #1894 rule
-  exists for.
+- *The `grep`-based Done-when criterion* ("returns only the two lines inside
+  `resolveDoctorPortsFromEnv`"). It is a drift guard the issue did not ask for, no test runs it,
+  and it was already false at HEAD (`src/cli/doctor.ts:2873`'s docblock) — a criterion that reads
+  red on correct code invites deleting an env-var name from a remedy that needs it.
+- *The three round-by-round correction logs.* Their substantive decisions are inline above: the
+  `0`/clamp rationale, the word-boundary assertions, test 3's own negative, the `http` listener
+  and timeout, and the both-variables scratch-home rule.
 
-**Not adopted**
+**Kept**
 
-- None.
-
-## Review corrections (round 2)
-
-**Adopted**
-
-- *Test 3's negative, copied from test 2, fails on correct code.* With only the MCP port bound,
-  `checkPorts` takes its partial branch and names `wsPort` — still the default 3478
-  (`src/cli/doctor.ts:2081-2084`). Test 3 now spells its own negative:
-  `not.toMatch(/\b3479\b/)`, with a sentence saying 3478 is expected to appear.
-- *The wiring specs' bare `net` listener makes doctor run `checkHealth` against a socket that
-  never answers — a 3 s stall inside vitest's 5 s default.* The MCP-port spec now specifies a
-  four-line `http.createServer` returning 404, and both wiring specs carry an explicit `20_000` ms
-  timeout with the PATH-walk reason in a comment (`httpGet` default `timeoutMs = 3000` at
-  `src/cli/doctor.ts:2219`; `cliAvailable`'s ~335 `statSync` calls at `:1258-1262`).
-- *The scratch-home rule cited a precedent that does not exist.* `tests/cli/doctor.test.ts:2026-2031`
-  stubs `HOME` only. The "exactly as … does" clause is gone; the paragraph now states the
-  both-variables rule as **new**, and says why the existing describe is safe with one stub
-  (`checkUserMcpConfig` reads `HOME || USERPROFILE` itself at `src/cli/doctor.ts:1107`) while
-  these specs, which run the whole doctor, are not.
-- *Done-when asserted a `runDoctor` no-env property that no test checks and the code does not
-  have.* Replaced with the checkable form — `runDoctor` gains no read of
-  `TANDEM_PORT`/`TANDEM_MCP_PORT`, the resolution site stays in `runDoctorCli` — plus a paragraph
-  naming what the header contract actually says. The same false claim in "Not changed, on
-  purpose" is corrected in place.
-
-**Not adopted**
-
-- None.
-
-## Review corrections (round 3)
-
-**Adopted**
-
-- *The Done-when grep criterion is already false at HEAD, and #1807 falsifies it a second time on
-  this branch* (raised twice). The criterion is now scoped to the read —
-  `grep -n 'process\.env\.TANDEM_PORT\|process\.env\.TANDEM_MCP_PORT' src/cli/doctor.ts` returns
-  only the two lines inside `resolveDoctorPortsFromEnv` — with both falsifying sites named
-  (`src/cli/doctor.ts:2873`'s docblock, and #1807's arm-4 `portFix` strings), so a reviewer does
-  not "fix" a red criterion by deleting the env-var name from a user-facing remedy.
-
-**Not adopted**
-
-- None.
+Everything the issue names: the two env vars reach `runDoctor` through the CLI wrapper, and the
+probed port is printed. No finding was outstanding against this spec.

--- a/docs/reviews/2026-09-02-v1-review/tracks/specs/F-doctor-1806.md
+++ b/docs/reviews/2026-09-02-v1-review/tracks/specs/F-doctor-1806.md
@@ -31,8 +31,16 @@ it.
   `Number.isInteger(n) && n >= 1 && n <= 65535 ? n : fallback`. `parseInt`, not `Number` and not
   `backend-ports.ts`'s `/^\d{1,5}$/` — the point is to probe **where the server actually binds**,
   and the server's `parseInt` binds `4918abc` on 4918. Diverging into a stricter parser would
-  re-create the false "not running" for exactly the inputs the server accepts. The range/NaN
-  guard covers only what the server would fail to bind at all.
+  re-create the false "not running" for exactly the inputs the server accepts.
+
+  **The `1..65535` clamp is a probe-side decision, not a mirror of the server, and `0` is the
+  case that proves it.** `src/server/index.ts:98` is a bare `parseInt` with no guard, and
+  `listen(0)` binds successfully on an OS-chosen ephemeral port — so `TANDEM_PORT=0` is not
+  "what the server would fail to bind". It is *undiagnosable from outside the process*: doctor
+  cannot know which port the kernel handed out, so neither `0` nor the default is a correct
+  probe. The clamp picks the default because that is the answer whose message (`3478 not
+  listening`) is at least a shape the user recognises. Say this in the code comment rather than
+  claiming the guard only covers unbindable input.
 - `resolveDoctorPortsFromEnv(env: NodeJS.ProcessEnv = process.env): { wsPort: number; mcpPort: number }`,
   **exported** (unit-testable, and the name says where it reads from), returning
   `{ wsPort: envPort(env.TANDEM_PORT, DEFAULT_WS_PORT), mcpPort: envPort(env.TANDEM_MCP_PORT, DEFAULT_MCP_PORT) }`.
@@ -53,21 +61,39 @@ CLI surface — see its header). No Y.Doc, no Y.Map, no testid, no `/api` route,
 
 ## Tests
 
-`tests/cli/doctor.test.ts`, in a new `describe`:
+`tests/cli/doctor.test.ts`, in a new `describe`.
+
+**The new describe stubs a scratch home, not just the port.** `RunDoctorCliOptions` is `{ json?:
+boolean }` (`src/cli/doctor.ts:2974-2976`) and `runDoctorCli` calls `runDoctor()` with no opts
+(`:3005`), so there is no `homeOverride` seam on this path: tests 2 and 3 run the *whole* doctor,
+including `checkUserMcpConfig` and `checkTandemPlugin`, which read `HOME`/`USERPROFILE`
+directly. The reads are read-only, but leaving them pointed at the operator's real home makes the
+specs' outcomes depend on machine state — the rule this group carries from #1894. So the
+describe's `beforeEach` does `mkdtempSync` plus `vi.stubEnv("HOME", dir)` **and**
+`vi.stubEnv("USERPROFILE", dir)` (both — `homedir()` reads `USERPROFILE` on Windows, which is the
+platform this wave runs on), exactly as the `checkUserMcpConfig wiring` describe does; `afterEach`
+does `vi.unstubAllEnvs()` and `rmSync`. The only live variable in these specs is the port.
 
 1. **Resolver table** on the exported `resolveDoctorPortsFromEnv({ TANDEM_PORT: …, TANDEM_MCP_PORT: … })`:
    `"4918"` → 4918; unset → 3478/3479; `""` → default (the `||` arm, which is why the server's
    spelling matters); `"4918abc"` → **4918**, not the default — kills a strict-regex resolver that
    would still misreport a server the real `parseInt` bound; `"abc"` → default; `"0"` and
-   `"70000"` → default.
+   `"70000"` → default (the clamp, per the comment above).
 2. **Wiring** — the discriminating one, because #1806 *is* a resolver-exists-but-is-not-called
    bug and a table test alone passes on the broken code. Bind a real `net` server on an ephemeral
    port, `vi.stubEnv("TANDEM_PORT", String(port))`, `vi.spyOn(process.stdout, "write")`, run
-   `await runDoctorCli({ json: true })`, `JSON.parse` the captured document, and assert the
-   `ports` result's `message` contains that port number and does **not** contain `3478`. Close the
-   listener in `afterEach`; `vi.unstubAllEnvs()`.
-3. Same shape for `TANDEM_MCP_PORT` with a listener bound on it, asserting the message names it —
-   kills a fix that wires only `wsPort` (the two are separate `??` reads).
+   `await runDoctorCli({ json: true })`, `JSON.parse` the captured document, and assert on the
+   `ports` result's `message`.
+
+   **Assert structurally, never by substring exclusion.** `expect(message).toMatch(new
+   RegExp(String.raw`\b${port}\b`))` for the probed port, and `expect(message).not.toMatch(/\b3478\b/)`
+   for the default. A bare `not.toContain("3478")` is an intermittent false red with no
+   diagnosable cause: ephemeral ports such as 33478, 43478, 53478, 63478 and 34780–34789 all
+   contain that digit string, and the harness cannot choose which one the kernel hands out.
+   Close the listener in `afterEach`.
+3. Same shape for `TANDEM_MCP_PORT` with a listener bound on it, asserting the message names it
+   under the same word-boundary rule — kills a fix that wires only `wsPort` (the two are separate
+   `??` reads).
 
 Both wiring tests must avoid the reserved harness ports and 3478/3479 by construction: take the
 port from a `listen(0)` handle, never a literal.
@@ -83,3 +109,29 @@ suite green.
 `src/server/index.ts`'s parse; a doctor check that *reports* an unparseable `TANDEM_PORT` (the
 fallback is silent, and the probed port is printed — see `assumptions`); `TANDEM_URL` /
 `TANDEM_BIND_HOST`; #1758's lock sequence.
+
+## Files touched
+
+`src/cli/doctor.ts`, `tests/cli/doctor.test.ts`.
+
+## Review corrections (round 1)
+
+**Adopted**
+
+- *`0` diverges from the server, which does bind `listen(0)`.* The spec asserted the clamp
+  "covers only what the server would fail to bind at all", which `src/server/index.ts:98`
+  contradicts. The Fix section now states the real reason `0` falls back — an ephemeral port is
+  undiagnosable from outside the process — and requires that reason in the code comment. The
+  table spec keeps `"0"` → default.
+- *The wiring specs' `not.toContain("3478")` is an intermittent false red.* Replaced with
+  word-boundary regexes in both directions (Tests 2 and 3), with the ephemeral-port collision
+  cases named so the assertion is not "simplified" back.
+- *The new describe runs the whole doctor against the real HOME.* Tests now open with an explicit
+  scratch-home rule: `mkdtempSync` plus `vi.stubEnv` on **both** `HOME` and `USERPROFILE`
+  (`homedir()` reads `USERPROFILE` on Windows), `vi.unstubAllEnvs()` in `afterEach` — matching the
+  existing `checkUserMcpConfig wiring` describe, and closing the machine-dependence the #1894 rule
+  exists for.
+
+**Not adopted**
+
+- None.

--- a/docs/reviews/2026-09-02-v1-review/tracks/specs/F-doctor-1807.md
+++ b/docs/reviews/2026-09-02-v1-review/tracks/specs/F-doctor-1807.md
@@ -97,6 +97,15 @@ Windows.
    `…:3479/mcp` pass assertion too, so an over-eager arm reds every working install.
 7. Port threading: `runDoctor({ mcpPort: 4918 })` with a `…:3479/mcp` entry in the scratch home →
    the warn names 4918. The only spec that proves `mcpPort` reaches this check.
+8. **Port-less URL**: `{ tandem: { type: "http", url: "http://127.0.0.1/mcp" } }` → a
+   `user-mcp-config` warn whose message names **`(none)`** and **`3479`**, with
+   `expect(warn?.fix).not.toMatch(/setup --apply/)`. This is the only spec that pins arm 3's
+   "treat a port-less URL as a mismatch" half: every other URL here carries an explicit port, and
+   spec 2's `…:3479/` short-circuits at arm 2 before arm 3 runs. Without it, the shape a reader
+   reaches for to avoid warning on a port-less URL — `if (parsedUrl.port && parsedUrl.port !==
+   String(mcpPort))` — is green on specs 1-7 while leaving port 80 reading
+   `tandem registered in ~/.claude.json`, which is exactly the issue's stated defect: green in the
+   file Claude Code consults, and Claude Code cannot connect.
 
 ## Done when
 
@@ -153,3 +162,13 @@ entry's own validation.
 Type, path and port validation at the user level with the observed values named; the stdio
 carve-out; the redaction rule (the entries this fires on are exactly the ones whose url can carry a
 credential, and the check reaches a prefilled public issue body).
+
+## Review corrections (post-cut)
+
+- **Spec 8 (port-less URL) added.** The seven specs left after the scope cut all carried an
+  explicit port, so arm 3's stated requirement — treat a missing `URL.port` as a mismatch and
+  report `(none)` — was pinned by nothing, and the natural `if (parsedUrl.port && …)` spelling
+  passed all of them while leaving `http://127.0.0.1/mcp` (port 80) green. This is **not** the
+  port-less-`https` spec the cut removed: that one existed to exercise `defaultPortForProtocol`,
+  which is still gone. This one exercises the `(none)` branch the cut's own replacement design
+  introduced.

--- a/docs/reviews/2026-09-02-v1-review/tracks/specs/F-doctor-1807.md
+++ b/docs/reviews/2026-09-02-v1-review/tracks/specs/F-doctor-1807.md
@@ -1,0 +1,90 @@
+# F-doctor — #1807 doctor passes a user-level `~/.claude.json` entry on key presence alone
+
+Branch `fix/doctor-and-skill-version-skew-1806`. Closes #1807. Ledger:
+`docs/reviews/2026-09-02-v1-review/areas/shared-cli.md:19`. No experiment (`[read]` row).
+**Depends on #1806** — the port comparison below probes the port doctor actually resolved.
+
+## Problem
+
+`checkUserMcpConfig` (`src/cli/doctor.ts`) does `if (!servers.tandem) warn else r.pass("tandem
+registered in ~/.claude.json")` — key presence, nothing else. Its project-level twin in
+`checkMcpJson` validates the same entry: `tandem.type !== "http" || !tandem.url?.includes("/mcp")`
+→ `warn(".mcp.json tandem: unexpected config — type=…, url=…")`. So a leftover entry from an older
+install (`type: "stdio"`, a URL with no `/mcp`, or 3479 after the user moved the server) reads
+green in the file Claude Code actually consults, while Claude Code cannot connect.
+
+The port half is real and not hypothetical: `buildMcpEntries` (`apply.ts:511`) writes
+`` `${MCP_URL}/mcp` `` with `MCP_URL` hardcoded to `DEFAULT_MCP_PORT` (`apply.ts:186`), so an
+install moved with `TANDEM_MCP_PORT` gets a config pointing at 3479 no matter what — and today
+nothing says so.
+
+## Fix
+
+`src/cli/doctor.ts` only.
+
+- Extract the inline `.mcp.json` branch into an exported pure
+  `evaluateTandemHttpEntry(entry: unknown, label: string, mcpPort: number): EvalOutcome | null`,
+  in the file's established `evaluateX` + `recordEvaluation` shape (model:
+  `evaluateOrphanedVite`, `evaluateTandemPlugin`). Order matters:
+  1. `entry` not an object → `null` (caller keeps its own missing/absent handling).
+  2. **A non-empty string `command` → `null`.** A stdio entry in `~/.claude.json` is a hand-edit
+     or a plugin-managed shape (the existing comment above `reportEntryCommand` says so), and
+     `reportEntryCommand` already owns it. Without this arm the new validator warns "unexpected
+     config" on every Claude-Desktop-style entry — a regression dressed as a fix.
+  3. `type !== "http"` or `url` missing / not parseable by `new URL()` / path not containing
+     `/mcp` → `warn`, message naming the observed `type=` and `url=` (the twin's wording, kept
+     verbatim so the two levels read alike), `fix` = `setupApplyRemedy(cliAvailable())` at the
+     user level and the existing `brokenFileFix()` at the project level — passed in by the caller,
+     not chosen inside, because a project-local `.mcp.json` is not Tandem's to rewrite.
+  4. URL port (`new URL(url).port || "80"`) ≠ `mcpPort` → `warn` naming **both** numbers and the
+     env var, e.g. `~/.claude.json tandem points at port 3479 but Tandem is configured for 4918
+     (TANDEM_MCP_PORT) — Claude Code will not connect`.
+  5. Otherwise `pass` with the existing text.
+- `warn`, never `fail`, in every arm — parity with the twin, and `tandem doctor` must not start
+  exiting 1 on a machine whose tools arrive via the plugin. (Assumption; see `assumptions`.)
+- Thread `mcpPort` from `runDoctor` into `checkMcpJson` and `checkUserMcpConfig` (both already
+  receive `r` and `cliAvailable`; add the parameter, no new option). `runDoctor` already has
+  `mcpPort` in scope — do **not** re-read the environment there (#1806 keeps one resolution site).
+- `checkUserMcpConfig` keeps reading `HOME`/`USERPROFILE` itself and keeps its `homeIsUnsafe`
+  screen (#1417) — the new code runs strictly after the read that already happened.
+- **`MAX_CONFIG_BYTES` is not added to doctor.** It does not fall out of this validation for free
+  (doctor reads through `readClaudeConfig`, a different reader from `readConfigForMutation`), and
+  the wave note says take it only if it does. Listed under `bryan`.
+
+Rules that bite: none of Critical Rules 1–9 touch this path; no route, no tool, no testid, no
+skill edit.
+
+## Tests
+
+`tests/cli/doctor.test.ts`, extending the existing `checkUserMcpConfig wiring (~/.claude.json)`
+describe (scratch HOME via `mkdtempSync` + `vi.stubEnv("HOME", …)` — **never the real HOME**):
+
+1. `{ tandem: { type: "stdio", url: "http://127.0.0.1:3479/mcp" } }` → `user-mcp-config` warn whose
+   message contains `type=stdio`. Kills "validate url only".
+2. `{ tandem: { type: "http", url: "http://127.0.0.1:3479/" } }` → warn naming the url. Kills
+   "validate type only".
+3. `{ tandem: { type: "http", url: "http://127.0.0.1:9999/mcp" } }` → warn naming **9999 and
+   3479**. Kills a validator that accepts any `/mcp` URL — the issue's headline case.
+4. `{ tandem: { command: "/abs/node", args: [...] } }` → **no** `unexpected config` warn from the
+   new validator. Kills arm 2 being dropped.
+5. The healthy entry (`type: "http"`, `…:3479/mcp`) still `pass`es — the existing BOM spec already
+   asserts this; add an explicit one so a future over-eager arm reds every working install.
+6. Project-level twin, in the `checkMcpJson` describe: the same wrong-port entry in a temp cwd's
+   `.mcp.json` warns too, and its `fix` still names `.mcp.json.example` (kills a copy-paste that
+   fixes one level and kills the other's remedy).
+7. Port mismatch under `TANDEM_MCP_PORT`: with #1806 wired, `vi.stubEnv("TANDEM_MCP_PORT", "4918")`
+   + a `…:3479/mcp` entry + `runDoctorCli({ json: true })` → the warn names 4918. This is the only
+   spec that proves the threading reaches the CLI rather than only `runDoctor(opts)`.
+
+## Done when
+
+Both levels run one validator; a wrong `type`, a URL without `/mcp`, and a port that disagrees
+with the probed MCP port each warn with the observed value; a stdio entry and a healthy HTTP entry
+are untouched; typecheck + the CLI suite green.
+
+## Not in scope
+
+A reachability comparison against a live server's advertised port (the probed port is the same
+answer with no ordering change — `user-mcp-config` runs before `ports`); `MAX_CONFIG_BYTES` in
+doctor; the `tandem-channel` entry's own validation; `apply.ts`'s hardcoded `MCP_URL` (a separate
+defect, named in the PR body, no issue in this group).

--- a/docs/reviews/2026-09-02-v1-review/tracks/specs/F-doctor-1807.md
+++ b/docs/reviews/2026-09-02-v1-review/tracks/specs/F-doctor-1807.md
@@ -49,18 +49,46 @@ nothing says so. **That also settles what arm 4's remedy may say; see below.**
      - **`Number(...)`, not a bare `.port`.** `URL.port` is a *string*; `"3479" !== 3479` is
        always true, so a literal comparison would warn on every healthy install (TS2367 catches
        it, but spell it correctly in the spec so it is not rediscovered).
-     - **The port-less default comes from the protocol, not a hardcoded `"80"`.**
-       `defaultPortForProtocol` returns 443 for `https:` and 80 otherwise; a port-less
-       `https://…/mcp` entry must not be reported as "points at port 80".
-  5. Otherwise `pass` with the existing text.
+     - **The port-less default comes from the protocol, not a hardcoded `"80"`.** Add a
+       module-private `defaultPortForProtocol(protocol: string): number` to `src/cli/doctor.ts`
+       — **it does not exist today** (`grep -rn defaultPortForProtocol src/` is empty); this spec
+       introduces it. It returns 443 for `https:` and 80 otherwise; a port-less `https://…/mcp`
+       entry must not be reported as "points at port 80".
+  5. Otherwise `pass` — **with a per-level message, not one shared string.** "The existing text"
+     differs at each level and there is no pass-message seam in `opts`, so spell both out or the
+     single natural implementation (`` `${label} tandem → ${url}` ``, the project wording at
+     `src/cli/doctor.ts:1045`) silently opens a *new* credential path through the pass arm:
+     - **`.mcp.json` (`redactUrl: false`)**: `` `${label} tandem → ${url}` ``, unchanged.
+     - **`~/.claude.json` (`redactUrl: true`)**: the byte-for-byte existing string
+       `tandem registered in ~/.claude.json` (`src/cli/doctor.ts:1209`). **It never interpolates
+       `url`, and it must not start.** Arms 3 and 4 do not fire on a healthy-*shaped* URL, so
+       `http://tok:s3cret@127.0.0.1:3479/mcp?key=abc` reaches the pass arm — same
+       `type`/`/mcp`/port as a clean install, and the credential is in the parts nothing looks
+       at. A pass arm that echoed `url` would put it on the wire for every such user, with
+       nothing warning them.
 
 - **The message is redacted at the user level and verbatim at the project level, and the two
   deliberately differ.** `opts.redactUrl` is what splits them:
   - **`.mcp.json` (`redactUrl: false`)** keeps today's wording byte-for-byte:
     `` `${label} tandem: unexpected config — type=${type}, url=${url}` ``.
-  - **`~/.claude.json` (`redactUrl: true`)** never interpolates the raw `url`. It prints
-    `type=<observed>` plus the parsed `port=` and `path=` (and, for a URL `new URL()` rejects,
-    the literal `url=(unparsable)` — the value itself is not echoed).
+  - **`~/.claude.json` (`redactUrl: true`)** never interpolates the raw `url`, **and never
+    interpolates the pathname either**:
+    - Arm 3 prints `type=<observed>` plus `pathHasMcp=false` (or, for a URL `new URL()` rejects,
+      the literal `url=(unparsable)`). **Not `path=<value>`.** A path segment is a standard
+      credential carrier for exactly this population — hosted MCP endpoints commonly embed the
+      key as `https://host/v1/<token>/mcp` — and `pathHasMcp=false` names the finding, which the
+      value does not add to. The `fix` string is what tells the user what to do.
+    - Arm 4 prints `type=` and the two port numbers only. **No path at all**: arm 4 fires only
+      when the pathname already contains `/mcp`, so the path is not the finding there — while
+      `/mcp/<secret>` satisfies that condition and would be printed verbatim.
+  - **Redaction covers the whole outcome, not just `message`.** At `redactUrl: true` the
+    outcome's `data` bag carries no `url` and no copy of the raw entry either.
+    `recordEvaluation` forwards `result.data` straight into `r.warn`
+    (`src/cli/doctor.ts:411-422`), and `redactUserPaths` "walks the WHOLE report" precisely
+    because "the per-check `data` bag is free-form and several checks put the raw directory in
+    it" (`diagnostics.ts:100-107`) — it collapses paths, and knows nothing about URL userinfo or
+    a query token. So `r.warn(msg, fix, { url })` would satisfy every message-only assertion and
+    still ship the credential.
 
   This is not symmetry for its own sake. The `.mcp.json` twin can echo safely only because
   `mcp-json` **is stripped from field reports**: it is in `CWD_DEPENDENT_CHECKS`
@@ -77,20 +105,45 @@ nothing says so. **That also settles what arm 4's remedy may say; see below.**
   whose `tandem` URL can carry userinfo or a query token. `type` stays verbatim in both: it is a
   short enum-shaped field, not a credential carrier.
 
-- **Arm 4 carries its own remedy and must never emit `setupApplyRemedy`.** `MCP_URL` is hardcoded
-  to `DEFAULT_MCP_PORT` (`apply.ts:186`, `:511`), so on a `TANDEM_MCP_PORT=4918` install
-  `tandem setup --apply` **re-writes 3479** and the warn re-fires unchanged, forever. That is the
-  dead-end-remedy defect this file has already been corrected for twice — `src/cli/doctor.ts:1163-1190`
-  (the #1802 malformed arm, which "carries NO `setupApplyRemedy`… prescribing either is a dead-end
-  fix line") and `:1345-1360` (the doctrine by name, #1404: *a remedy that cannot work is worse
-  than no remedy*). So `portFix` names the two things that actually work, and says what
-  `setup --apply` would do:
+- **Arm 4 carries its own remedy and must never emit `setupApplyRemedy` — at EITHER level.**
+  `MCP_URL` is hardcoded to `DEFAULT_MCP_PORT` (`apply.ts:186`, `:511`), so on a
+  `TANDEM_MCP_PORT=4918` install `tandem setup --apply` **re-writes 3479** and the warn re-fires
+  unchanged, forever. That is the dead-end-remedy defect this file has already been corrected for
+  twice — `src/cli/doctor.ts:1163-1190` (the #1802 malformed arm, which "carries NO
+  `setupApplyRemedy`… prescribing either is a dead-end fix line") and `:1345-1360` (the doctrine
+  by name, #1404: *a remedy that cannot work is worse than no remedy*).
 
-  > Edit the `url` in ~/.claude.json to port `<mcpPort>`, or unset `TANDEM_MCP_PORT` and restart
-  > Tandem. `tandem setup --apply` writes the default port and will not fix this.
+  **So `portFix` is supplied at BOTH call sites, and is never `brokenFileFix()`.**
+  `brokenFileFix` ends in `setupApplyRemedy(cliAvailable())` (`src/cli/doctor.ts:986-988`, already
+  asserted to match `/tandem setup --apply|AI Assistant/` at `tests/cli/doctor.test.ts:2168-2170`),
+  and its other half — "delete it and rely on Tandem's global registration" — falls back to
+  `~/.claude.json`, which names 3479 too. Both branches re-fire the same warn forever. Doctor
+  already says in-product that a project-local `.mcp.json` is "not managed by … `tandem setup
+  --apply`" (`:1077-1081`), so the remedy is doubly dead there.
 
-  `brokenFix` (arm 3) keeps `setupApplyRemedy(cliAvailable())` at the user level — for a wrong
-  `type` or a `/mcp`-less URL, rewriting the entry genuinely resolves it.
+  - **`~/.claude.json`** (`portFix`):
+
+    > Edit the `url` in ~/.claude.json to port `<mcpPort>`, or unset `TANDEM_MCP_PORT` and restart
+    > Tandem. `tandem setup --apply` writes the default port and will not fix this. (#<MCP_URL issue>)
+
+  - **`.mcp.json`** (`portFix`): names the file the user must edit, since it is theirs:
+
+    > Edit the `url` in .mcp.json to port `<mcpPort>`, or unset `TANDEM_MCP_PORT` and restart
+    > Tandem — this project-local file is not managed by `tandem setup --apply`.
+    > (#<MCP_URL issue>)
+
+  `brokenFix` (arm 3) is the one that keeps a rewrite remedy: `setupApplyRemedy(cliAvailable())` at
+  the user level, `brokenFileFix()` at the project level. For a wrong `type` or a `/mcp`-less URL,
+  rewriting the entry genuinely resolves it.
+
+- **The arm-4 warn is unclearable for a deliberately moved install, and that is a chosen cost.**
+  Because `MCP_URL` is hardcoded, no Tandem-written config can satisfy arm 4 on a
+  `TANDEM_MCP_PORT` install — the only ways out are hand-editing the file or abandoning the port
+  move, and the warn persists until the tracked `MCP_URL` issue lands. That is the same
+  unclearable-warning shape `src/cli/doctor.ts:1938` warns against, so it is stated here as a
+  trade rather than left to be discovered: a *correct* warning naming a real misconfiguration
+  beats a green check on a config Claude Code cannot use. Arm 4's `fix` cites the issue number, so
+  the user sees the same reasoning.
 
 - `warn`, never `fail`, in every arm — parity with the twin, and `tandem doctor` must not start
   exiting 1 on a machine whose tools arrive via the plugin. (Assumption; see `assumptions`.)
@@ -109,47 +162,72 @@ skill edit.
 ## Tests
 
 `tests/cli/doctor.test.ts`, extending the existing `checkUserMcpConfig wiring (~/.claude.json)`
-describe (scratch HOME via `mkdtempSync` + `vi.stubEnv("HOME", …)` — **never the real HOME**):
+describe. Its `beforeEach` stubs `HOME` only today (`tests/cli/doctor.test.ts:2026-2031`); **it
+gains `vi.stubEnv("USERPROFILE", home)` in the same commit**, so specs 1–9 are machine-independent
+on Windows too and spec 10 — which runs the whole doctor through `runDoctorCli` and so reaches
+`checkTandemPlugin`'s `homedir()`-adjacent reads — does not need a describe of its own. Scratch
+HOME via `mkdtempSync`, `vi.unstubAllEnvs()` in `afterEach` — **never the real HOME**:
 
 1. `{ tandem: { type: "stdio", url: "http://127.0.0.1:3479/mcp" } }` → `user-mcp-config` warn whose
    message contains `type=stdio`. Kills "validate url only".
-2. `{ tandem: { type: "http", url: "http://127.0.0.1:3479/" } }` → warn naming `path=/`, and the
-   message must **not** contain the raw `http://127.0.0.1:3479/`. Kills "validate type only", and
-   pins the redaction.
+2. `{ tandem: { type: "http", url: "http://127.0.0.1:3479/" } }` → warn naming `pathHasMcp=false`,
+   and the message must **not** contain the raw `http://127.0.0.1:3479/` (nor a `path=` value).
+   Kills "validate type only", and pins the redaction's shape-not-value rule for arm 3.
 3. `{ tandem: { type: "http", url: "http://127.0.0.1:9999/mcp" } }` → warn naming **9999 and
    3479**. Kills a validator that accepts any `/mcp` URL — the issue's headline case. Plus
    `expect(warn?.fix).not.toMatch(/setup --apply/)`, mirroring `tests/cli/doctor.test.ts:2057`:
    the dead-end remedy is the half that ships silently.
-4. **Redaction, discriminating case.** `{ tandem: { type: "http", url:
-   "http://tok:s3cret@example.invalid:9999/mcp?key=abc" } }` → warn that names 9999, and whose
-   `message` contains **neither** `s3cret` **nor** `key=abc`. Kills a copy of the twin's verbatim
-   `url=` interpolation at the level that reaches a prefilled public issue body.
+4. **Redaction, discriminating cases — asserted over the WHOLE outcome, not `message`.** Two
+   entries, each `→` a warn that names 9999 and whose `JSON.stringify(warn)` contains **none** of
+   the credential strings. `JSON.stringify`, not `warn?.message`: it covers `message`, `fix` and
+   the `data` bag in one non-sniffable check, and `data` is the channel a message-only assertion
+   misses entirely (see the redaction bullet).
+   - `{ type: "http", url: "http://tok:s3cret@example.invalid:9999/mcp?key=abc" }` → contains
+     neither `s3cret` nor `key=abc` nor the raw url. Kills a copy of the twin's verbatim `url=`
+     interpolation at the level that reaches a prefilled public issue body.
+   - `{ type: "http", url: "http://example.invalid:9999/mcp/s3cret" }` → contains neither
+     `s3cret` nor the raw url. Kills arm 4 printing `path=`, which is a live token carrier
+     precisely because arm 4 requires `/mcp` in the pathname.
 5. `{ tandem: { command: "/abs/node", args: [...] } }` → **no** `unexpected config` warn from the
    new validator. Kills arm 2 being dropped at the user level.
-6. The healthy entry (`type: "http"`, `…:3479/mcp`) still `pass`es — the existing BOM spec already
-   asserts this; add an explicit one so a future over-eager arm reds every working install.
+6. **The healthy entry passes AND says nothing about the url.** Use a healthy-*shaped* entry that
+   carries a credential payload: `{ type: "http", url: "http://tok:s3cret@127.0.0.1:3479/mcp?key=abc" }`
+   → a `user-mcp-config` **pass** whose `JSON.stringify` contains neither `s3cret` nor `key=abc`
+   nor the raw url — the pass message stays the existing `tandem registered in ~/.claude.json`.
+   Asserting only `status === "pass"` is non-discriminating on exactly the property this arm
+   exists to establish. Keep a plain `…:3479/mcp` pass assertion too, so a future over-eager arm
+   reds every working install.
 7. Port-less `https`: `{ tandem: { type: "http", url: "https://example.invalid/mcp" } }` warns
    naming **443**, not 80. Kills the hardcoded `|| "80"` default.
-8. Project-level twin, in the `checkMcpJson` describe: the same wrong-port entry in a temp cwd's
-   `.mcp.json` warns too, and its `fix` **gains** `brokenFileFix()` — the project arm carries no
-   `fix` at all today (`src/cli/doctor.ts:1042-1043` passes one argument), so this pins new
-   behaviour rather than preserving old.
+8. Project-level twin, in the `checkMcpJson` describe. Two entries, and which one gets which
+   remedy is the point — the project arm carries no `fix` at all today
+   (`src/cli/doctor.ts:1042-1043` passes one argument), so both pin new behaviour:
+   - **Arm 3** (wrong `type`, or a `/mcp`-less URL) in a temp cwd's `.mcp.json` → warn whose `fix`
+     **gains `brokenFileFix()`**. Rewriting the entry genuinely fixes this one.
+   - **Arm 4** (the same wrong-port entry) → warn whose `fix` is the project-level `portFix`,
+     naming editing `.mcp.json`'s `url`, plus
+     `expect(warn?.fix).not.toMatch(/setup --apply/)` — the assertion spec 3 already carries at
+     the user level. `brokenFileFix()` ends in `setupApplyRemedy(cliAvailable())`
+     (`src/cli/doctor.ts:986-988`), so pinning it here would ship and lock in the dead-end remedy
+     the Fix section forbids.
 9. **Project-level `command` entry** — the arm-2 regression guard. A `.mcp.json` whose `tandem`
    entry is `{ command: "/abs/node", args: [] }` still produces an `mcp-json` **warn** and must
    NOT produce a `pass` containing `undefined`. Without `commandArmOwnedByCaller` this spec is
    the one that reds.
 10. Port mismatch under `TANDEM_MCP_PORT`: with #1806 wired, `vi.stubEnv("TANDEM_MCP_PORT", "4918")`
     + a `…:3479/mcp` entry + `runDoctorCli({ json: true })` → the warn names 4918. This is the only
-    spec that proves the threading reaches the CLI rather than only `runDoctor(opts)`. Same
-    scratch-home rule as #1806's wiring describe: stub **both** `HOME` and `USERPROFILE`.
+    spec that proves the threading reaches the CLI rather than only `runDoctor(opts)`. It relies
+    on the `USERPROFILE` stub added to this describe's `beforeEach` above — the same both-variables
+    rule as #1806's wiring describe, for the same reason (this spec runs the whole doctor).
 
 ## Done when
 
 A wrong `type`, a URL without `/mcp`, and a port that disagrees with the probed MCP port each warn
-with the observed value at **both** levels; the user-level message never echoes the raw `url`
-while the project-level one still does; the port warn's `fix` does not name `setup --apply`; a
-stdio entry warns at the project level and is left to `reportEntryCommand` at the user level; a
-healthy HTTP entry passes; typecheck + the CLI suite green.
+with the observed value at **both** levels; **no `user-mcp-config` outcome — warn or pass, in
+`message`, `fix` or `data` — echoes the raw `url` or any part of its path**, while the
+project-level one still does; the port warn's `fix` does not name `setup --apply` at **either**
+level; a stdio entry warns at the project level and is left to `reportEntryCommand` at the user
+level; a healthy HTTP entry passes; typecheck + the CLI suite green.
 
 ## Not in scope
 
@@ -164,7 +242,17 @@ mention.** It is deliberately not bundled: `MCP_URL` also feeds the desktop stdi
 decision, not a mechanical two-line fix. So it exceeds "bundle small tangential fixes in". **The
 PR must file an issue for it and cite that number here before merging**; a note living only in a
 PR body surfaces in no `gh issue list`, which is the failure mode CLAUDE.md's dated-gates rule
-names. Arm 4's remedy is what keeps the user unblocked in the meantime.
+names. Arm 4's remedy — and its `fix` string — cite that number, which is what keeps the user
+unblocked in the meantime.
+
+**Naming the rule this departs from**, so a reviewer does not read the new issue as an untracked
+deferral: CLAUDE.md's Development Workflow says "if you find something broken while working, fix
+it rather than filing it", and this sweep's own Decision B for #1827 chose "**No new issue** —
+#1754 stays open with a comment" (`docs/plans/2026-09-06-open-issues-sweep.md:24`). The departure
+is deliberate and narrow: choosing *which* environment `MCP_URL` should read — the setup shell's
+or the server's — is a design call with three consumers (the MCP entry, the desktop stdio entry's
+`TANDEM_URL` at `apply.ts:502`, and the shim's at `:518`), not a mechanical fix, and no existing
+issue covers it. File one rather than commenting on an unrelated one.
 
 ## Files touched
 
@@ -209,3 +297,51 @@ names. Arm 4's remedy is what keeps the user unblocked in the meantime.
   environment is not necessarily the server's — so choosing what it should read is a design call
   that would land untested inside a doctor-only PR, against this wave's minimal-fix lesson. The
   tracked-issue requirement above is taken instead.
+
+## Review corrections (round 2)
+
+**Adopted**
+
+- **BLOCKING** *The shared evaluator leaks the raw `~/.claude.json` `url` through its PASS arm.*
+  "Otherwise `pass` with the existing text" had no per-level seam, so the natural implementation
+  is the project wording `` `${label} tandem → ${url}` `` (`src/cli/doctor.ts:1045`) — and arms 3
+  and 4 do not fire on a healthy-shaped URL, so `http://tok:s3cret@127.0.0.1:3479/mcp?key=abc`
+  reaches it. Arm 5 now spells both messages out: the user level stays the byte-for-byte existing
+  `tandem registered in ~/.claude.json` (`:1209`) and never interpolates `url`. Spec 6 is
+  repointed onto a healthy-shaped entry carrying a credential payload and asserts the absence,
+  not just the status.
+- **BLOCKING** *Redaction was asserted only against `message`, while the per-check `data` bag
+  reaches `/api/diagnostics` and the prefilled issue body unscrubbed for credentials.*
+  `recordEvaluation` forwards `result.data` into `r.warn` (`src/cli/doctor.ts:411-422`) and
+  `redactUserPaths` collapses paths only (`diagnostics.ts:83-115`, and `:100-107` says it walks
+  the whole report *because* `data` is free-form). The redaction bullet now covers the whole
+  outcome — no `url` and no raw entry in `data` — and specs 4 and 6 assert over
+  `JSON.stringify(warn)` / `JSON.stringify(pass)` rather than `?.message`.
+- **BLOCKING** *Arm 4's `path=` prints a credential-carrying path component: `/mcp/<secret>`
+  satisfies the "pathname contains `/mcp`" condition the arm fires under.* The user-level message
+  now prints **no path value at all**: arm 4 is `type=` plus the two port numbers, and arm 3 is
+  `type=` plus `pathHasMcp=false`. Spec 2 is repointed onto `pathHasMcp=false`; spec 4 gains a
+  `http://example.invalid:9999/mcp/s3cret` case.
+- **BLOCKING** *The spec contradicted itself on the port-mismatch remedy — spec 8 pinned
+  `brokenFileFix()`, which ends in `setupApplyRemedy(cliAvailable())`
+  (`src/cli/doctor.ts:986-988`), for the one arm the Fix forbids it in* (raised twice). The Fix
+  now states `portFix` is supplied at **both** call sites and is never `brokenFileFix()`, gives
+  the project-level wording (edit `.mcp.json`'s `url`, which doctor already says at `:1077-1081`
+  that `setup --apply` does not manage), and spec 8 is split: arm 3 gains `brokenFileFix()`, arm 4
+  gets `portFix` plus `expect(warn?.fix).not.toMatch(/setup --apply/)`.
+- *`defaultPortForProtocol` was described as though it exists.* `grep -rn defaultPortForProtocol
+  src/` is empty; the Fix now marks it as a new module-private helper in `src/cli/doctor.ts`.
+- *The arm-4 warn is unclearable for a deliberately moved install — the same shape the spec cites
+  doctrine against.* Added as an explicit stated trade in the Fix, with the reason it is still the
+  right call, and arm 4's `fix` now cites the `MCP_URL` issue number so the user sees it too.
+- *Requiring a new issue for `MCP_URL` departs from the two-person fix-rather-than-file rule and
+  from this sweep's own Decision-B precedent, without saying so.* Not-in-scope now names both
+  rules and why this one is a design call with three consumers rather than a mechanical fix.
+- *Specs 1–9 extend a `HOME`-only describe while spec 10 needs both variables.* The Tests preamble
+  now requires `vi.stubEnv("USERPROFILE", home)` in that describe's `beforeEach` in the same
+  commit (`tests/cli/doctor.test.ts:2026-2031` stubs `HOME` alone today), and spec 10 refers to it
+  rather than restating a separate rule.
+
+**Not adopted**
+
+- None.

--- a/docs/reviews/2026-09-02-v1-review/tracks/specs/F-doctor-1807.md
+++ b/docs/reviews/2026-09-02-v1-review/tracks/specs/F-doctor-1807.md
@@ -6,40 +6,92 @@ Branch `fix/doctor-and-skill-version-skew-1806`. Closes #1807. Ledger:
 
 ## Problem
 
-`checkUserMcpConfig` (`src/cli/doctor.ts`) does `if (!servers.tandem) warn else r.pass("tandem
+`checkUserMcpConfig` (`src/cli/doctor.ts:1213`) does `if (!servers.tandem) warn else r.pass("tandem
 registered in ~/.claude.json")` — key presence, nothing else. Its project-level twin in
-`checkMcpJson` validates the same entry: `tandem.type !== "http" || !tandem.url?.includes("/mcp")`
-→ `warn(".mcp.json tandem: unexpected config — type=…, url=…")`. So a leftover entry from an older
+`checkMcpJson` validates the same entry (`src/cli/doctor.ts:1041-1043`):
+`tandem.type !== "http" || !tandem.url?.includes("/mcp")` →
+`warn(".mcp.json tandem: unexpected config — type=…, url=…")`. So a leftover entry from an older
 install (`type: "stdio"`, a URL with no `/mcp`, or 3479 after the user moved the server) reads
 green in the file Claude Code actually consults, while Claude Code cannot connect.
 
 The port half is real and not hypothetical: `buildMcpEntries` (`apply.ts:511`) writes
 `` `${MCP_URL}/mcp` `` with `MCP_URL` hardcoded to `DEFAULT_MCP_PORT` (`apply.ts:186`), so an
 install moved with `TANDEM_MCP_PORT` gets a config pointing at 3479 no matter what — and today
-nothing says so.
+nothing says so. **That also settles what arm 4's remedy may say; see below.**
 
 ## Fix
 
 `src/cli/doctor.ts` only.
 
 - Extract the inline `.mcp.json` branch into an exported pure
-  `evaluateTandemHttpEntry(entry: unknown, label: string, mcpPort: number): EvalOutcome | null`,
-  in the file's established `evaluateX` + `recordEvaluation` shape (model:
-  `evaluateOrphanedVite`, `evaluateTandemPlugin`). Order matters:
+  `evaluateTandemHttpEntry(entry, opts): EvalOutcome | null`, in the file's established
+  `evaluateX` + `recordEvaluation` shape (model: `evaluateOrphanedVite`, `evaluateTandemPlugin`).
+  `opts` carries `label`, `mcpPort`, `redactUrl: boolean`, `commandArmOwnedByCaller: boolean`,
+  `brokenFix: string` and `portFix: string`. Order matters:
+
   1. `entry` not an object → `null` (caller keeps its own missing/absent handling).
-  2. **A non-empty string `command` → `null`.** A stdio entry in `~/.claude.json` is a hand-edit
-     or a plugin-managed shape (the existing comment above `reportEntryCommand` says so), and
-     `reportEntryCommand` already owns it. Without this arm the new validator warns "unexpected
-     config" on every Claude-Desktop-style entry — a regression dressed as a fix.
-  3. `type !== "http"` or `url` missing / not parseable by `new URL()` / path not containing
-     `/mcp` → `warn`, message naming the observed `type=` and `url=` (the twin's wording, kept
-     verbatim so the two levels read alike), `fix` = `setupApplyRemedy(cliAvailable())` at the
-     user level and the existing `brokenFileFix()` at the project level — passed in by the caller,
-     not chosen inside, because a project-local `.mcp.json` is not Tandem's to rewrite.
-  4. URL port (`new URL(url).port || "80"`) ≠ `mcpPort` → `warn` naming **both** numbers and the
-     env var, e.g. `~/.claude.json tandem points at port 3479 but Tandem is configured for 4918
-     (TANDEM_MCP_PORT) — Claude Code will not connect`.
+  2. **A non-empty string `command` → `null`, but ONLY when `commandArmOwnedByCaller` is true.**
+     This arm is a **user-level** fact, not a property of the entry shape. At `~/.claude.json`
+     a stdio entry is a hand-edit or a plugin-managed shape and `reportEntryCommand` already owns
+     it (`src/cli/doctor.ts:1213`), so warning "unexpected config" there would be a regression
+     dressed as a fix. `checkMcpJson` calls `reportEntryCommand` for the **channel** entry only
+     (`:1074`) and never for `tandem`, so making arm 2 unconditional would delete the project
+     level's only diagnostic for a stdio `tandem` entry and hand it to the `else` arm, which
+     emits `r.pass('.mcp.json tandem → undefined')` — a warn silently replaced by a false pass.
+     So: `commandArmOwnedByCaller: true` at the `~/.claude.json` call site, `false` at
+     `.mcp.json`.
+  3. `type !== "http"`, or `url` missing / not parseable by `new URL()`, or the parsed pathname not
+     containing `/mcp` → `warn`, `fix` = `opts.brokenFix` (`setupApplyRemedy(cliAvailable())` at the
+     user level, the existing `brokenFileFix()` at the project level — passed in by the caller, not
+     chosen inside, because a project-local `.mcp.json` is not Tandem's to rewrite).
+  4. `Number(parsedUrl.port || defaultPortForProtocol(parsedUrl.protocol)) !== mcpPort` → `warn`
+     naming **both** numbers and the env var, `fix` = `opts.portFix`.
+     - **`Number(...)`, not a bare `.port`.** `URL.port` is a *string*; `"3479" !== 3479` is
+       always true, so a literal comparison would warn on every healthy install (TS2367 catches
+       it, but spell it correctly in the spec so it is not rediscovered).
+     - **The port-less default comes from the protocol, not a hardcoded `"80"`.**
+       `defaultPortForProtocol` returns 443 for `https:` and 80 otherwise; a port-less
+       `https://…/mcp` entry must not be reported as "points at port 80".
   5. Otherwise `pass` with the existing text.
+
+- **The message is redacted at the user level and verbatim at the project level, and the two
+  deliberately differ.** `opts.redactUrl` is what splits them:
+  - **`.mcp.json` (`redactUrl: false`)** keeps today's wording byte-for-byte:
+    `` `${label} tandem: unexpected config — type=${type}, url=${url}` ``.
+  - **`~/.claude.json` (`redactUrl: true`)** never interpolates the raw `url`. It prints
+    `type=<observed>` plus the parsed `port=` and `path=` (and, for a URL `new URL()` rejects,
+    the literal `url=(unparsable)` — the value itself is not echoed).
+
+  This is not symmetry for its own sake. The `.mcp.json` twin can echo safely only because
+  `mcp-json` **is stripped from field reports**: it is in `CWD_DEPENDENT_CHECKS`
+  (`src/cli/doctor.ts:455-461`), which `filterDevRepoChecks`
+  (`src/server/mcp/routes/diagnostics.ts:56-69`) drops from `/api/diagnostics`.
+  `user-mcp-config` is **not** in that list, and `checkUserMcpConfig`'s own docblock
+  (`src/cli/doctor.ts:1173-1180`) says why that matters: *"~/.claude.json carries bearer tokens /
+  API keys. This check survives the /api/diagnostics filter, so its message reaches the Copy
+  Diagnostics clipboard — destined for public issues."* The only scrubber left downstream is
+  `redactUserPaths` (`diagnostics.ts:83-115`), which collapses home and app-data **paths** and
+  knows nothing about a credential in a URL — and the Report-a-bug link prefills a public issue
+  body, which makes the human review step an opt-out. Arms 3 and 4 fire precisely on entries
+  Tandem did not write (hand-edited, another install, a remote host), which is the population
+  whose `tandem` URL can carry userinfo or a query token. `type` stays verbatim in both: it is a
+  short enum-shaped field, not a credential carrier.
+
+- **Arm 4 carries its own remedy and must never emit `setupApplyRemedy`.** `MCP_URL` is hardcoded
+  to `DEFAULT_MCP_PORT` (`apply.ts:186`, `:511`), so on a `TANDEM_MCP_PORT=4918` install
+  `tandem setup --apply` **re-writes 3479** and the warn re-fires unchanged, forever. That is the
+  dead-end-remedy defect this file has already been corrected for twice — `src/cli/doctor.ts:1163-1190`
+  (the #1802 malformed arm, which "carries NO `setupApplyRemedy`… prescribing either is a dead-end
+  fix line") and `:1345-1360` (the doctrine by name, #1404: *a remedy that cannot work is worse
+  than no remedy*). So `portFix` names the two things that actually work, and says what
+  `setup --apply` would do:
+
+  > Edit the `url` in ~/.claude.json to port `<mcpPort>`, or unset `TANDEM_MCP_PORT` and restart
+  > Tandem. `tandem setup --apply` writes the default port and will not fix this.
+
+  `brokenFix` (arm 3) keeps `setupApplyRemedy(cliAvailable())` at the user level — for a wrong
+  `type` or a `/mcp`-less URL, rewriting the entry genuinely resolves it.
+
 - `warn`, never `fail`, in every arm — parity with the twin, and `tandem doctor` must not start
   exiting 1 on a machine whose tools arrive via the plugin. (Assumption; see `assumptions`.)
 - Thread `mcpPort` from `runDoctor` into `checkMcpJson` and `checkUserMcpConfig` (both already
@@ -61,30 +113,99 @@ describe (scratch HOME via `mkdtempSync` + `vi.stubEnv("HOME", …)` — **never
 
 1. `{ tandem: { type: "stdio", url: "http://127.0.0.1:3479/mcp" } }` → `user-mcp-config` warn whose
    message contains `type=stdio`. Kills "validate url only".
-2. `{ tandem: { type: "http", url: "http://127.0.0.1:3479/" } }` → warn naming the url. Kills
-   "validate type only".
+2. `{ tandem: { type: "http", url: "http://127.0.0.1:3479/" } }` → warn naming `path=/`, and the
+   message must **not** contain the raw `http://127.0.0.1:3479/`. Kills "validate type only", and
+   pins the redaction.
 3. `{ tandem: { type: "http", url: "http://127.0.0.1:9999/mcp" } }` → warn naming **9999 and
-   3479**. Kills a validator that accepts any `/mcp` URL — the issue's headline case.
-4. `{ tandem: { command: "/abs/node", args: [...] } }` → **no** `unexpected config` warn from the
-   new validator. Kills arm 2 being dropped.
-5. The healthy entry (`type: "http"`, `…:3479/mcp`) still `pass`es — the existing BOM spec already
+   3479**. Kills a validator that accepts any `/mcp` URL — the issue's headline case. Plus
+   `expect(warn?.fix).not.toMatch(/setup --apply/)`, mirroring `tests/cli/doctor.test.ts:2057`:
+   the dead-end remedy is the half that ships silently.
+4. **Redaction, discriminating case.** `{ tandem: { type: "http", url:
+   "http://tok:s3cret@example.invalid:9999/mcp?key=abc" } }` → warn that names 9999, and whose
+   `message` contains **neither** `s3cret` **nor** `key=abc`. Kills a copy of the twin's verbatim
+   `url=` interpolation at the level that reaches a prefilled public issue body.
+5. `{ tandem: { command: "/abs/node", args: [...] } }` → **no** `unexpected config` warn from the
+   new validator. Kills arm 2 being dropped at the user level.
+6. The healthy entry (`type: "http"`, `…:3479/mcp`) still `pass`es — the existing BOM spec already
    asserts this; add an explicit one so a future over-eager arm reds every working install.
-6. Project-level twin, in the `checkMcpJson` describe: the same wrong-port entry in a temp cwd's
-   `.mcp.json` warns too, and its `fix` still names `.mcp.json.example` (kills a copy-paste that
-   fixes one level and kills the other's remedy).
-7. Port mismatch under `TANDEM_MCP_PORT`: with #1806 wired, `vi.stubEnv("TANDEM_MCP_PORT", "4918")`
-   + a `…:3479/mcp` entry + `runDoctorCli({ json: true })` → the warn names 4918. This is the only
-   spec that proves the threading reaches the CLI rather than only `runDoctor(opts)`.
+7. Port-less `https`: `{ tandem: { type: "http", url: "https://example.invalid/mcp" } }` warns
+   naming **443**, not 80. Kills the hardcoded `|| "80"` default.
+8. Project-level twin, in the `checkMcpJson` describe: the same wrong-port entry in a temp cwd's
+   `.mcp.json` warns too, and its `fix` **gains** `brokenFileFix()` — the project arm carries no
+   `fix` at all today (`src/cli/doctor.ts:1042-1043` passes one argument), so this pins new
+   behaviour rather than preserving old.
+9. **Project-level `command` entry** — the arm-2 regression guard. A `.mcp.json` whose `tandem`
+   entry is `{ command: "/abs/node", args: [] }` still produces an `mcp-json` **warn** and must
+   NOT produce a `pass` containing `undefined`. Without `commandArmOwnedByCaller` this spec is
+   the one that reds.
+10. Port mismatch under `TANDEM_MCP_PORT`: with #1806 wired, `vi.stubEnv("TANDEM_MCP_PORT", "4918")`
+    + a `…:3479/mcp` entry + `runDoctorCli({ json: true })` → the warn names 4918. This is the only
+    spec that proves the threading reaches the CLI rather than only `runDoctor(opts)`. Same
+    scratch-home rule as #1806's wiring describe: stub **both** `HOME` and `USERPROFILE`.
 
 ## Done when
 
-Both levels run one validator; a wrong `type`, a URL without `/mcp`, and a port that disagrees
-with the probed MCP port each warn with the observed value; a stdio entry and a healthy HTTP entry
-are untouched; typecheck + the CLI suite green.
+A wrong `type`, a URL without `/mcp`, and a port that disagrees with the probed MCP port each warn
+with the observed value at **both** levels; the user-level message never echoes the raw `url`
+while the project-level one still does; the port warn's `fix` does not name `setup --apply`; a
+stdio entry warns at the project level and is left to `reportEntryCommand` at the user level; a
+healthy HTTP entry passes; typecheck + the CLI suite green.
 
 ## Not in scope
 
 A reachability comparison against a live server's advertised port (the probed port is the same
 answer with no ordering change — `user-mcp-config` runs before `ports`); `MAX_CONFIG_BYTES` in
-doctor; the `tandem-channel` entry's own validation; `apply.ts`'s hardcoded `MCP_URL` (a separate
-defect, named in the PR body, no issue in this group).
+doctor; the `tandem-channel` entry's own validation.
+
+**`apply.ts`'s hardcoded `MCP_URL` is a real defect and needs a tracked home, not a PR-body
+mention.** It is deliberately not bundled: `MCP_URL` also feeds the desktop stdio entry's
+`TANDEM_URL` and the channel shim's, and deriving it from the *setup shell's*
+`TANDEM_MCP_PORT` — which need not be the environment the server is launched in — is a design
+decision, not a mechanical two-line fix. So it exceeds "bundle small tangential fixes in". **The
+PR must file an issue for it and cite that number here before merging**; a note living only in a
+PR body surfaces in no `gh issue list`, which is the failure mode CLAUDE.md's dated-gates rule
+names. Arm 4's remedy is what keeps the user unblocked in the meantime.
+
+## Files touched
+
+`src/cli/doctor.ts`, `tests/cli/doctor.test.ts`.
+
+## Review corrections (round 1)
+
+**Adopted**
+
+- *The user-level message would echo the raw `url` of `~/.claude.json` into a check that survives
+  the `/api/diagnostics` filter and reaches a prefilled public issue body.* Added `redactUrl` to
+  the evaluator's options and a dedicated paragraph in Fix: the user level prints `type=`, `port=`
+  and `path=` (or `url=(unparsable)`), the project level keeps the verbatim wording, and the spec
+  now states why the two differ, with the `CWD_DEPENDENT_CHECKS` / `filterDevRepoChecks` /
+  `redactUserPaths` chain cited. New discriminating spec 4 (userinfo + query token).
+- *Arm 4 inherited `setupApplyRemedy`, which provably re-writes the same wrong port* (raised
+  three times). Arm 4 now takes its own `portFix`, the spec states it must never emit
+  `setupApplyRemedy` while `MCP_URL` is hardcoded, and spec 3 asserts
+  `fix).not.toMatch(/setup --apply/)` against the existing precedent at `doctor.test.ts:2057`.
+- *Arm 2 applied to the shared validator deletes the project level's only stdio diagnostic and
+  replaces it with `pass('… → undefined')`.* Arm 2 is now gated on `commandArmOwnedByCaller`,
+  true only at `~/.claude.json`, with the two `reportEntryCommand` call sites cited. New spec 9
+  pins the project-level `command` entry.
+- *`new URL(url).port || "80"` mis-reads a port-less `https` entry.* The default now comes from
+  the parsed protocol (443 / 80), with new spec 7.
+- *The port comparison mixes a string and a number.* Spelled `Number(...) !== mcpPort` in the Fix,
+  with the TS2367 note.
+- *Test 6 described a preserved `fix` the project arm does not have.* Reworded (now spec 8): the
+  project arm **gains** `brokenFileFix()`; `doctor.ts:1042-1043` passes one argument today.
+- *Done-when's "Both levels run one validator" is enforced by no test.* Softened to the
+  observable properties the specs actually assert (each condition warns at both levels, plus the
+  redaction and remedy splits), rather than a structural claim nothing checks.
+- *`apply.ts`'s `MCP_URL` was parked with "named in the PR body", against the two-person
+  fix-rather-than-file rule.* Not-in-scope now explains why bundling it is a design decision
+  rather than a small fix, and **requires the PR to file a tracked issue and cite the number
+  here**.
+
+**Not adopted**
+
+- *Bundle the `MCP_URL` fix into this PR* (the alternative offered by the same finding). `MCP_URL`
+  also feeds the desktop stdio entry's `TANDEM_URL` and the channel shim's, and the setup shell's
+  environment is not necessarily the server's — so choosing what it should read is a design call
+  that would land untested inside a doctor-only PR, against this wave's minimal-fix lesson. The
+  tracked-issue requirement above is taken instead.

--- a/docs/reviews/2026-09-02-v1-review/tracks/specs/F-doctor-1807.md
+++ b/docs/reviews/2026-09-02-v1-review/tracks/specs/F-doctor-1807.md
@@ -1,419 +1,155 @@
 # F-doctor — #1807 doctor passes a user-level `~/.claude.json` entry on key presence alone
 
 Branch `fix/doctor-and-skill-version-skew-1806`. Closes #1807. Ledger:
-`docs/reviews/2026-09-02-v1-review/areas/shared-cli.md:19`. No experiment (`[read]` row).
-**Depends on #1806** — the port comparison below probes the port doctor actually resolved.
+`docs/reviews/2026-09-02-v1-review/areas/shared-cli.md:19`. **Depends on #1806** — the port it
+compares against is the one doctor actually probed.
 
 ## Problem
 
-`checkUserMcpConfig` (`src/cli/doctor.ts:1213`) does `if (!servers.tandem) warn else r.pass("tandem
-registered in ~/.claude.json")` — key presence, nothing else. Its project-level twin in
-`checkMcpJson` validates the same entry (`src/cli/doctor.ts:1041-1043`):
-`tandem.type !== "http" || !tandem.url?.includes("/mcp")` →
-`warn(".mcp.json tandem: unexpected config — type=…, url=…")`. So a leftover entry from an older
-install (`type: "stdio"`, a URL with no `/mcp`, or 3479 after the user moved the server) reads
-green in the file Claude Code actually consults, while Claude Code cannot connect.
+`checkUserMcpConfig` (`src/cli/doctor.ts:1206-1213`) does `if (!servers.tandem) warn else
+r.pass("tandem registered in ~/.claude.json")` — key presence, nothing else. Its project-level twin
+validates the same entry (`:1042-1043`): `tandem.type !== "http" || !tandem.url?.includes("/mcp")`
+→ warn. So a leftover entry from an older install (`type: "stdio"`, a URL with no `/mcp`, or 3479
+after the user moved the server) reads green in the file Claude Code actually consults, while
+Claude Code cannot connect.
 
-The port half is real and not hypothetical: `buildMcpEntries` (`apply.ts:511`) writes
-`` `${MCP_URL}/mcp` `` with `MCP_URL` hardcoded to `DEFAULT_MCP_PORT` (`apply.ts:186`), so an
-install moved with `TANDEM_MCP_PORT` gets a config pointing at 3479 no matter what — and today
-nothing says so. **That also settles what arm 4's remedy may say; see below.**
+The port half is real: `buildMcpEntries` writes `` `${MCP_URL}/mcp` `` with `MCP_URL` hardcoded to
+`DEFAULT_MCP_PORT` (`apply.ts:186`, `:511`), so an install moved with `TANDEM_MCP_PORT` gets a
+config pointing at 3479 no matter what — and nothing says so today.
 
 ## Fix
 
-`src/cli/doctor.ts` only.
+`src/cli/doctor.ts` only. **The user level gains the validation; `checkMcpJson` is not touched
+and no shared evaluator is introduced** (see the scope cut).
 
-- Extract the inline `.mcp.json` branch into an exported pure
-  `evaluateTandemHttpEntry(entry, opts): EvalOutcome | null`, in the file's established
-  `evaluateX` + `recordEvaluation` shape (model: `evaluateOrphanedVite`, `evaluateTandemPlugin`).
-  `opts` carries `label`, `mcpPort`, `redactUrl: boolean`, `commandArmOwnedByCaller: boolean`,
-  `brokenFix: string` and `portFix: string`. Order matters:
+- Thread the port: `checkUserMcpConfig(r, cliAvailable, mcpPort)`, called from `runDoctor`, which
+  already has `mcpPort` in scope (`:2877`). No new option, no second env read (#1806 keeps one
+  resolution site).
+- Module-private `validateUserTandemEntry(entry, mcpPort, cliAvailable): { message, fix } | null`,
+  applied where `r.pass("tandem registered in ~/.claude.json")` is today. `null` → that same pass,
+  byte-for-byte; otherwise `r.warn(message, fix)`. `reportEntryCommand` still runs either way.
+  Order:
+  1. A non-empty string `command` → `null`. A stdio entry in `~/.claude.json` is a hand-edit or a
+     plugin-managed shape, and `reportEntryCommand` (`:1213`) already owns it — warning
+     "unexpected config" there is a regression dressed as a fix.
+  2. `type !== "http"`, or `url` missing / not parseable by `new URL()`, or the parsed pathname not
+     containing `/mcp` → message `` `~/.claude.json tandem: unexpected config — type=${type},
+     pathHasMcp=${bool}` `` (or `url=(unparsable)`), `fix` = `setupApplyRemedy(cliAvailable())`.
+     **`pathHasMcp` is computed, not the constant `false`** — this arm also fires on a bad `type`
+     with a perfectly good `/mcp` path (test 1), where a hardcoded `false` would be a false
+     statement in doctor output.
+  3. `parsedUrl.port !== String(mcpPort)` → message naming the observed port (or `(none)` when the
+     URL carries none) and `mcpPort`, `fix`: *edit the `url` in `~/.claude.json` to port `<mcpPort>`,
+     or unset `TANDEM_MCP_PORT` and restart Tandem*. **Compare the string form and treat a
+     port-less URL as a mismatch** — the entry must name Tandem's MCP port explicitly; that is what
+     kills the `URL.port`-is-a-string bug (`"3479" !== 3479` is always true) without a
+     `defaultPortForProtocol` helper.
+  4. Otherwise `null`.
+- **The port warn must never emit `setupApplyRemedy`.** `MCP_URL` is hardcoded, so `setup --apply`
+  re-writes 3479 and the warn re-fires forever — the dead-end-remedy defect this file has already
+  been corrected for twice (`src/cli/doctor.ts:1163-1190`, and the doctrine by name at
+  `:1345-1360`). The warn is unclearable on a deliberately moved install until `MCP_URL` is fixed;
+  that is a chosen cost — a correct warning beats a green check on a config Claude Code cannot use.
+- **No message and no `data` bag interpolates the `url` or any part of its path.**
+  `checkUserMcpConfig`'s own docblock (`:1173-1180`) records why: `~/.claude.json` carries bearer
+  tokens, `user-mcp-config` survives the `/api/diagnostics` filter, and the Report-a-bug link
+  prefills a public issue body. The only scrubber downstream, `redactUserPaths`
+  (`diagnostics.ts:83-115`), collapses paths and knows nothing about URL userinfo or a query token
+  — and `r.warn` forwards `data` verbatim, so `r.warn(msg, fix, { url })` would satisfy every
+  message-only assertion and still ship the credential. `type` stays verbatim (enum-shaped).
+- `warn`, never `fail` — parity with the twin; `tandem doctor` must not start exiting 1 on a
+  machine whose tools arrive via the plugin.
 
-  1. `entry` not an object → `null` (caller keeps its own missing/absent handling).
-  2. **A non-empty string `command` → `null`, but ONLY when `commandArmOwnedByCaller` is true.**
-     This arm is a **user-level** fact, not a property of the entry shape. At `~/.claude.json`
-     a stdio entry is a hand-edit or a plugin-managed shape and `reportEntryCommand` already owns
-     it (`src/cli/doctor.ts:1213`), so warning "unexpected config" there would be a regression
-     dressed as a fix. `checkMcpJson` calls `reportEntryCommand` for the **channel** entry only
-     (`:1074`) and never for `tandem`, so making arm 2 unconditional would delete the project
-     level's only diagnostic for a stdio `tandem` entry and hand it to the `else` arm, which
-     emits `r.pass('.mcp.json tandem → undefined')` — a warn silently replaced by a false pass.
-     So: `commandArmOwnedByCaller: true` at the `~/.claude.json` call site, `false` at
-     `.mcp.json`.
-  3. `type !== "http"`, or `url` missing / not parseable by `new URL()`, or the parsed pathname not
-     containing `/mcp` → `warn`, `fix` = `opts.brokenFix` (`setupApplyRemedy(cliAvailable())` at the
-     user level, the existing `brokenFileFix()` at the project level — passed in by the caller, not
-     chosen inside, because a project-local `.mcp.json` is not Tandem's to rewrite).
-  4. `Number(parsedUrl.port || defaultPortForProtocol(parsedUrl.protocol)) !== mcpPort` → `warn`
-     naming **both** numbers and the env var, `fix` = `opts.portFix`.
-     - **`Number(...)`, not a bare `.port`.** `URL.port` is a *string*; `"3479" !== 3479` is
-       always true, so a literal comparison would warn on every healthy install (TS2367 catches
-       it, but spell it correctly in the spec so it is not rediscovered).
-     - **The port-less default comes from the protocol, not a hardcoded `"80"`.** Add a
-       module-private `defaultPortForProtocol(protocol: string): number` to `src/cli/doctor.ts`
-       — **it does not exist today** (`grep -rn defaultPortForProtocol src/` is empty); this spec
-       introduces it. It returns 443 for `https:` and 80 otherwise; a port-less `https://…/mcp`
-       entry must not be reported as "points at port 80".
-  5. Otherwise `pass` — **with a per-level message, not one shared string.** "The existing text"
-     differs at each level and there is no pass-message seam in `opts`, so spell both out or the
-     single natural implementation (`` `${label} tandem → ${url}` ``, the project wording at
-     `src/cli/doctor.ts:1045`) silently opens a *new* credential path through the pass arm:
-     - **`.mcp.json` (`redactUrl: false`)**: `` `${label} tandem → ${url}` ``, unchanged.
-     - **`~/.claude.json` (`redactUrl: true`)**: the byte-for-byte existing string
-       `tandem registered in ~/.claude.json` (`src/cli/doctor.ts:1209`). **It never interpolates
-       `url`, and it must not start.** Arms 3 and 4 do not fire on a healthy-*shaped* URL, so
-       `http://tok:s3cret@127.0.0.1:3479/mcp?key=abc` reaches the pass arm — same
-       `type`/`/mcp`/port as a clean install, and the credential is in the parts nothing looks
-       at. A pass arm that echoed `url` would put it on the wire for every such user, with
-       nothing warning them.
-
-- **The message is redacted at the user level and verbatim at the project level, and the two
-  deliberately differ.** `opts.redactUrl` is what splits them:
-  - **`.mcp.json` (`redactUrl: false`)** keeps today's wording byte-for-byte **for arm 3 only**:
-    `` `${label} tandem: unexpected config — type=${type}, url=${url}` ``.
-  - **Arm 4's message never interpolates `url`, at EITHER level.** The two port numbers are the
-    whole finding, and arm 4 fires only on urls that already passed the shape checks — a
-    `type: "http"`, `/mcp`-terminated url naming a non-default port is exactly the hosted or remote
-    endpoint most likely to carry a credential, so widening today's verbatim project-level echo
-    onto that population is a new exposure rather than preserved wording. The exposure would be
-    bounded (`mcp-json` is in `CWD_DEPENDENT_CHECKS`, `src/cli/doctor.ts:455-461`, and
-    `filterDevRepoChecks` strips it from `/api/diagnostics` and `tandem_diagnostics`,
-    `src/server/mcp/routes/diagnostics.ts:39,57`), which is why it is a message rule rather than a
-    second `redactUrl` level — but "bounded to the CLI terminal" is not a reason to print it.
-  - **`~/.claude.json` (`redactUrl: true`)** never interpolates the raw `url`, **and never
-    interpolates the pathname either**:
-    - Arm 3 prints `type=<observed>` plus `pathHasMcp=<computed boolean>` (or, for a URL
-      `new URL()` rejects, the literal `url=(unparsable)`). **The boolean is computed, not the
-      constant `false`**: arm 3 also fires on `type !== "http"` with a perfectly good `/mcp`
-      pathname (test 1 is exactly that entry), where a hardcoded `pathHasMcp=false` would be a
-      false statement in doctor output. **Not `path=<value>`.** A path segment is a standard
-      credential carrier for exactly this population — hosted MCP endpoints commonly embed the
-      key as `https://host/v1/<token>/mcp` — and `pathHasMcp=false` names the finding, which the
-      value does not add to. The `fix` string is what tells the user what to do.
-    - Arm 4 prints `type=` and the two port numbers only. **No path at all**: arm 4 fires only
-      when the pathname already contains `/mcp`, so the path is not the finding there — while
-      `/mcp/<secret>` satisfies that condition and would be printed verbatim.
-  - **Redaction covers the whole outcome, not just `message`.** At `redactUrl: true` the
-    outcome's `data` bag carries no `url` and no copy of the raw entry either.
-    `recordEvaluation` forwards `result.data` straight into `r.warn`
-    (`src/cli/doctor.ts:411-422`), and `redactUserPaths` "walks the WHOLE report" precisely
-    because "the per-check `data` bag is free-form and several checks put the raw directory in
-    it" (`diagnostics.ts:100-107`) — it collapses paths, and knows nothing about URL userinfo or
-    a query token. So `r.warn(msg, fix, { url })` would satisfy every message-only assertion and
-    still ship the credential.
-
-  This is not symmetry for its own sake. The `.mcp.json` twin can echo safely only because
-  `mcp-json` **is stripped from field reports**: it is in `CWD_DEPENDENT_CHECKS`
-  (`src/cli/doctor.ts:455-461`), which `filterDevRepoChecks`
-  (`src/server/mcp/routes/diagnostics.ts:56-69`) drops from `/api/diagnostics`.
-  `user-mcp-config` is **not** in that list, and `checkUserMcpConfig`'s own docblock
-  (`src/cli/doctor.ts:1173-1180`) says why that matters: *"~/.claude.json carries bearer tokens /
-  API keys. This check survives the /api/diagnostics filter, so its message reaches the Copy
-  Diagnostics clipboard — destined for public issues."* The only scrubber left downstream is
-  `redactUserPaths` (`diagnostics.ts:83-115`), which collapses home and app-data **paths** and
-  knows nothing about a credential in a URL — and the Report-a-bug link prefills a public issue
-  body, which makes the human review step an opt-out. Arms 3 and 4 fire precisely on entries
-  Tandem did not write (hand-edited, another install, a remote host), which is the population
-  whose `tandem` URL can carry userinfo or a query token. `type` stays verbatim in both: it is a
-  short enum-shaped field, not a credential carrier.
-
-- **Arm 4 carries its own remedy and must never emit `setupApplyRemedy` — at EITHER level.**
-  `MCP_URL` is hardcoded to `DEFAULT_MCP_PORT` (`apply.ts:186`, `:511`), so on a
-  `TANDEM_MCP_PORT=4918` install `tandem setup --apply` **re-writes 3479** and the warn re-fires
-  unchanged, forever. That is the dead-end-remedy defect this file has already been corrected for
-  twice — `src/cli/doctor.ts:1163-1190` (the #1802 malformed arm, which "carries NO
-  `setupApplyRemedy`… prescribing either is a dead-end fix line") and `:1345-1360` (the doctrine
-  by name, #1404: *a remedy that cannot work is worse than no remedy*).
-
-  **So `portFix` is supplied at BOTH call sites, and is never `brokenFileFix()`.**
-  `brokenFileFix` ends in `setupApplyRemedy(cliAvailable())` (`src/cli/doctor.ts:986-988`, already
-  asserted to match `/tandem setup --apply|AI Assistant/` at `tests/cli/doctor.test.ts:2168-2170`),
-  and its other half — "delete it and rely on Tandem's global registration" — falls back to
-  `~/.claude.json`, which names 3479 too. Both branches re-fire the same warn forever. Doctor
-  already says in-product that a project-local `.mcp.json` is "not managed by … `tandem setup
-  --apply`" (`:1077-1081`), so the remedy is doubly dead there.
-
-  - **`~/.claude.json`** (`portFix`):
-
-    > Edit the `url` in ~/.claude.json to port `<mcpPort>`, or unset `TANDEM_MCP_PORT` and restart
-    > Tandem. `tandem setup --apply` writes the default port and will not fix this. (#<MCP_URL issue>)
-
-  - **`.mcp.json`** (`portFix`): names the file the user must edit, since it is theirs:
-
-    > Edit the `url` in .mcp.json to port `<mcpPort>`, or unset `TANDEM_MCP_PORT` and restart
-    > Tandem — this project-local file is not managed by `tandem setup --apply`.
-    > (#<MCP_URL issue>)
-
-  `brokenFix` (arm 3) is the one that keeps a rewrite remedy: `setupApplyRemedy(cliAvailable())` at
-  the user level, `brokenFileFix()` at the project level. For a wrong `type` or a `/mcp`-less URL,
-  rewriting the entry genuinely resolves it.
-
-- **The arm-4 warn is unclearable for a deliberately moved install, and that is a chosen cost.**
-  Because `MCP_URL` is hardcoded, no Tandem-written config can satisfy arm 4 on a
-  `TANDEM_MCP_PORT` install — the only ways out are hand-editing the file or abandoning the port
-  move, and the warn persists until the tracked `MCP_URL` issue lands. That is the same
-  unclearable-warning shape `src/cli/doctor.ts:1938` warns against, so it is stated here as a
-  trade rather than left to be discovered: a *correct* warning naming a real misconfiguration
-  beats a green check on a config Claude Code cannot use. Arm 4's `fix` cites the issue number, so
-  the user sees the same reasoning.
-
-- `warn`, never `fail`, in every arm — parity with the twin, and `tandem doctor` must not start
-  exiting 1 on a machine whose tools arrive via the plugin. (Assumption; see `assumptions`.)
-- Thread `mcpPort` from `runDoctor` into `checkMcpJson` and `checkUserMcpConfig` (both already
-  receive `r` and `cliAvailable`; add the parameter, no new option). `runDoctor` already has
-  `mcpPort` in scope — do **not** re-read the environment there (#1806 keeps one resolution site).
-- `checkUserMcpConfig` keeps reading `HOME`/`USERPROFILE` itself and keeps its `homeIsUnsafe`
-  screen (#1417) — the new code runs strictly after the read that already happened.
-- **`MAX_CONFIG_BYTES` is not added to doctor.** It does not fall out of this validation for free
-  (doctor reads through `readClaudeConfig`, a different reader from `readConfigForMutation`), and
-  the wave note says take it only if it does. Listed under `bryan`.
-
-Rules that bite: none of Critical Rules 1–9 touch this path; no route, no tool, no testid, no
-skill edit.
+Rules that bite: none of Critical Rules 1–9 touch this path; no route, no tool, no testid, no skill
+edit.
 
 ## Tests
 
 `tests/cli/doctor.test.ts`, extending the existing `checkUserMcpConfig wiring (~/.claude.json)`
-describe. Its `beforeEach` stubs `HOME` only today (`tests/cli/doctor.test.ts:2026-2031`); **it
-gains `vi.stubEnv("USERPROFILE", home)` in the same commit**, so specs 1–9 are machine-independent
-on Windows too and spec 10 — which runs the whole doctor through `runDoctorCli` and so reaches
-`checkTandemPlugin`'s `homedir()`-adjacent reads — does not need a describe of its own. Scratch
-HOME via `mkdtempSync`, `vi.unstubAllEnvs()` in `afterEach` — **never the real HOME**:
+describe (scratch `mkdtempSync` home, `vi.unstubAllEnvs()` in `afterEach` — **never the real
+HOME**). Its `beforeEach` stubs `HOME` only today (`:2026-2031`); **it gains
+`vi.stubEnv("USERPROFILE", home)` in the same commit** so the specs are machine-independent on
+Windows.
 
 1. `{ tandem: { type: "stdio", url: "http://127.0.0.1:3479/mcp" } }` → `user-mcp-config` warn whose
-   message contains `type=stdio` **and `pathHasMcp=true`**. Kills "validate url only", and pins
-   `pathHasMcp` as computed rather than a constant — this entry's pathname does contain `/mcp`.
+   message contains `type=stdio` **and `pathHasMcp=true`**. Kills "validate url only" and pins the
+   computed boolean.
 2. `{ tandem: { type: "http", url: "http://127.0.0.1:3479/" } }` → warn naming `pathHasMcp=false`,
-   and the message must **not** contain the raw `http://127.0.0.1:3479/` (nor a `path=` value).
-   Kills "validate type only", and pins the redaction's shape-not-value rule for arm 3.
+   and the message must not contain the raw url. Kills "validate type only".
 3. `{ tandem: { type: "http", url: "http://127.0.0.1:9999/mcp" } }` → warn naming **9999 and
-   3479**. Kills a validator that accepts any `/mcp` URL — the issue's headline case. Plus
-   `expect(warn?.fix).not.toMatch(/setup --apply/)`, mirroring `tests/cli/doctor.test.ts:2057`:
-   the dead-end remedy is the half that ships silently. **And
-   `expect(warn?.fix).toMatch(/#\d{3,}/)`** — `portFix`'s wording ends in the `MCP_URL` issue
-   number, which is filed during this PR (see Not in scope). Nothing else would catch a literal
-   `(#<MCP_URL issue>)` placeholder shipping in a user-facing remedy.
-4. **Redaction, discriminating cases — asserted over EVERY `user-mcp-config` outcome, not one
-   found result and not `message`.** Two entries, each `→` a warn that names 9999, with the
-   absence asserted over
-   `JSON.stringify(report.results.filter((x) => x.check === "user-mcp-config"))`.
-   `JSON.stringify`, not `warn?.message`: it covers `message`, `fix` and the `data` bag in one
-   non-sniffable check, and `data` is the channel a message-only assertion misses entirely (see the
-   redaction bullet). **The filter, not a single `find`:** `checkUserMcpConfig` emits several
-   results under that check name (`src/cli/doctor.ts:1206-1230` — the tandem outcome, then
-   `reportEntryCommand`, then the two channel outcomes), so a leak in a sibling outcome is
-   invisible to a one-result assertion.
-   - `{ type: "http", url: "http://tok:s3cret@example.invalid:9999/mcp?key=abc" }` → contains
-     neither `s3cret` nor `key=abc` nor the raw url. Kills a copy of the twin's verbatim `url=`
-     interpolation at the level that reaches a prefilled public issue body.
-   - `{ type: "http", url: "http://example.invalid:9999/mcp/s3cret" }` → contains neither
-     `s3cret` nor the raw url. Kills arm 4 printing `path=`, which is a live token carrier
-     precisely because arm 4 requires `/mcp` in the pathname.
-5. `{ tandem: { command: "/abs/node", args: [...] } }` → **assert the POSITIVE, wording-independent
-   outcome**: the `user-mcp-config` results **contain a pass whose message is
-   `tandem registered in ~/.claude.json`** (`src/cli/doctor.ts:1209`), and `reportEntryCommand`'s
-   own outcome for the stdio entry still appears. That pass is reachable only when the evaluator
-   returns `null` for a `command` entry, so it reds if arm 2 is made unconditional — and it also
-   reds on an implementation that returns `null` **and emits nothing at all**, which today's
-   `recordEvaluation` (`src/cli/doctor.ts:411-413`, silent on `null`) makes easy to ship. A bare
-   "no `unexpected config` warn" assertion catches neither: the Fix pins that substring only for
-   the **project**-level message (`redactUrl: false`), so the user-level warn is free to be worded
-   differently and pass vacuously with arm 2 dropped. Keep
-   `expect(JSON.stringify(userResults)).not.toContain("unexpected config")` as a secondary
-   assertion only.
-6. **The healthy entry passes AND says nothing about the url.** Use a healthy-*shaped* entry that
-   carries a credential payload: `{ type: "http", url: "http://tok:s3cret@127.0.0.1:3479/mcp?key=abc" }`
-   → a `user-mcp-config` **pass** whose message is the existing `tandem registered in
-   ~/.claude.json`, with the absence asserted over
-   `JSON.stringify(report.results.filter((x) => x.check === "user-mcp-config"))` — neither
-   `s3cret` nor `key=abc` nor the raw url, in **any** outcome under that check name (same
-   sibling-outcome reason as spec 4). Asserting only `status === "pass"` is non-discriminating on
-   exactly the property this arm exists to establish. Keep a plain `…:3479/mcp` pass assertion too,
-   so a future over-eager arm reds every working install.
-7. Port-less `https`: `{ tandem: { type: "http", url: "https://example.invalid/mcp" } }` warns
-   naming **443**, not 80. Kills the hardcoded `|| "80"` default.
-8. Project-level twin, in the `checkMcpJson` describe. Two entries, and which one gets which
-   remedy is the point — the project arm carries no `fix` at all today
-   (`src/cli/doctor.ts:1042-1043` passes one argument), so both pin new behaviour:
-   - **Arm 3** (wrong `type`, or a `/mcp`-less URL) in a temp cwd's `.mcp.json` → warn whose `fix`
-     **gains `brokenFileFix()`**. Rewriting the entry genuinely fixes this one.
-   - **Arm 4** (the same wrong-port entry) → warn whose `fix` is the project-level `portFix`,
-     naming editing `.mcp.json`'s `url`, plus
-     `expect(warn?.fix).not.toMatch(/setup --apply/)` and `expect(warn?.fix).toMatch(/#\d{3,}/)` —
-     both assertions spec 3 already carries at the user level. `brokenFileFix()` ends in
-     `setupApplyRemedy(cliAvailable())` (`src/cli/doctor.ts:986-988`), so pinning it here would
-     ship and lock in the dead-end remedy the Fix section forbids. **And
-     `expect(warn?.message).not.toContain(url)`** — arm 4's message names the two ports and never
-     the url, at this level too (see the redaction bullet).
-9. **Project-level `command` entry** — the arm-2 regression guard. A `.mcp.json` whose `tandem`
-   entry is `{ command: "/abs/node", args: [] }` still produces an `mcp-json` **warn** and must
-   NOT produce a `pass` containing `undefined`. Without `commandArmOwnedByCaller` this spec is
-   the one that reds.
-10. Port mismatch under `TANDEM_MCP_PORT`: with #1806 wired, `vi.stubEnv("TANDEM_MCP_PORT", "4918")`
-    + a `…:3479/mcp` entry + `runDoctorCli({ json: true })` → the warn names 4918. This is the only
-    spec that proves the threading reaches the CLI rather than only `runDoctor(opts)`. It relies
-    on the `USERPROFILE` stub added to this describe's `beforeEach` above — the same both-variables
-    rule as #1806's wiring describe, for the same reason (this spec runs the whole doctor).
+   3479**, plus `expect(warn?.fix).not.toMatch(/setup --apply/)` (precedent:
+   `tests/cli/doctor.test.ts:2057`). The issue's headline case, and the dead-end remedy is the half
+   that ships silently.
+4. **Redaction**, asserted over `JSON.stringify(report.results.filter((x) => x.check ===
+   "user-mcp-config"))` — the whole filtered set, not one `find` (`checkUserMcpConfig` emits
+   several outcomes under that name, `:1206-1230`), and `JSON.stringify` so `fix` and the `data`
+   bag are covered, not just `message`. Two entries: `http://tok:s3cret@example.invalid:9999/mcp?key=abc`
+   and `http://example.invalid:9999/mcp/s3cret` → each warns, and neither `s3cret`, `key=abc` nor
+   the raw url appears anywhere.
+5. `{ tandem: { command: "/abs/node", args: [] } }` → the `user-mcp-config` results **contain the
+   pass whose message is `tandem registered in ~/.claude.json`** (`:1209`), and
+   `reportEntryCommand`'s own outcome still appears. Assert the positive: that pass is reachable
+   only when arm 1 returns `null`, so it reds if the `command` arm is dropped **and** if the
+   validator returns `null` while emitting nothing at all.
+6. **Healthy entry passes and says nothing about the url**:
+   `{ type: "http", url: "http://tok:s3cret@127.0.0.1:3479/mcp?key=abc" }` → a **pass** with the
+   existing message, and the same stringified-absence assertion as spec 4. Keep a plain
+   `…:3479/mcp` pass assertion too, so an over-eager arm reds every working install.
+7. Port threading: `runDoctor({ mcpPort: 4918 })` with a `…:3479/mcp` entry in the scratch home →
+   the warn names 4918. The only spec that proves `mcpPort` reaches this check.
 
 ## Done when
 
 A wrong `type`, a URL without `/mcp`, and a port that disagrees with the probed MCP port each warn
-with the observed value at **both** levels; **no `user-mcp-config` outcome — warn or pass, in
-`message`, `fix` or `data` — echoes the raw `url` or any part of its path**, while the
-project-level one still does; the port warn's `fix` does not name `setup --apply` at **either**
-level; a stdio entry warns at the project level and is left to `reportEntryCommand` at the user
-level; a healthy HTTP entry passes; typecheck + the CLI suite green.
+at the user level; no `user-mcp-config` outcome — warn or pass, in `message`, `fix` or `data` —
+echoes the raw `url` or any part of its path; the port warn's `fix` does not name `setup --apply`;
+a stdio entry still passes and is left to `reportEntryCommand`; a healthy HTTP entry passes;
+typecheck + the CLI suite green.
 
 ## Not in scope
 
-A reachability comparison against a live server's advertised port (the probed port is the same
-answer with no ordering change — `user-mcp-config` runs before `ports`); `MAX_CONFIG_BYTES` in
-doctor; the `tandem-channel` entry's own validation.
+`checkMcpJson` and the project-level `.mcp.json` messages (unchanged); a reachability comparison
+against a live server's advertised port; `MAX_CONFIG_BYTES` in doctor (it does not fall out of this
+validation — doctor reads through `readClaudeConfig`, a different reader from
+`readConfigForMutation` — and the wave note says take it only if it does); the `tandem-channel`
+entry's own validation.
 
-**`apply.ts`'s hardcoded `MCP_URL` is a real defect and needs a tracked home, not a PR-body
-mention.** It is deliberately not bundled: `MCP_URL` also feeds the desktop stdio entry's
-`TANDEM_URL` and the channel shim's, and deriving it from the *setup shell's*
-`TANDEM_MCP_PORT` — which need not be the environment the server is launched in — is a design
-decision, not a mechanical two-line fix. So it exceeds "bundle small tangential fixes in". **The
-PR must file an issue for it and cite that number here before merging**; a note living only in a
-PR body surfaces in no `gh issue list`, which is the failure mode CLAUDE.md's dated-gates rule
-names. Arm 4's remedy — and its `fix` string — cite that number, which is what keeps the user
-unblocked in the meantime.
+## For Bryan
 
-**Naming the rule this departs from**, so a reviewer does not read the new issue as an untracked
-deferral: CLAUDE.md's Development Workflow says "if you find something broken while working, fix
-it rather than filing it", and this sweep's own Decision B for #1827 chose "**No new issue** —
-#1754 stays open with a comment" (`docs/plans/2026-09-06-open-issues-sweep.md:24`). The departure
-is deliberate and narrow: choosing *which* environment `MCP_URL` should read — the setup shell's
-or the server's — is a design call with three consumers (the MCP entry, the desktop stdio entry's
-`TANDEM_URL` at `apply.ts:502`, and the shim's at `:518`), not a mechanical fix, and no existing
-issue covers it. File one rather than commenting on an unrelated one.
+- **`apply.ts`'s hardcoded `MCP_URL`** (`:186`, `:511`) writes 3479 into every config regardless of
+  `TANDEM_MCP_PORT`, which is what makes arm 3's warn unclearable on a moved install. Fixing it is
+  a design call, not a mechanical edit: `MCP_URL` also feeds the desktop stdio entry's `TANDEM_URL`
+  (`:502`) and the shim's (`:518`), and the *setup shell's* environment need not be the server's.
+- `tandem doctor` has no config size cap while `setup` refuses at 16 MiB (#1891's For-Bryan item).
 
 ## Files touched
 
 `src/cli/doctor.ts`, `tests/cli/doctor.test.ts`.
 
-## Review corrections (round 1)
+## Review corrections (scope cut)
 
-**Adopted**
+**Removed**
 
-- *The user-level message would echo the raw `url` of `~/.claude.json` into a check that survives
-  the `/api/diagnostics` filter and reaches a prefilled public issue body.* Added `redactUrl` to
-  the evaluator's options and a dedicated paragraph in Fix: the user level prints `type=`, `port=`
-  and `path=` (or `url=(unparsable)`), the project level keeps the verbatim wording, and the spec
-  now states why the two differ, with the `CWD_DEPENDENT_CHECKS` / `filterDevRepoChecks` /
-  `redactUserPaths` chain cited. New discriminating spec 4 (userinfo + query token).
-- *Arm 4 inherited `setupApplyRemedy`, which provably re-writes the same wrong port* (raised
-  three times). Arm 4 now takes its own `portFix`, the spec states it must never emit
-  `setupApplyRemedy` while `MCP_URL` is hardcoded, and spec 3 asserts
-  `fix).not.toMatch(/setup --apply/)` against the existing precedent at `doctor.test.ts:2057`.
-- *Arm 2 applied to the shared validator deletes the project level's only stdio diagnostic and
-  replaces it with `pass('… → undefined')`.* Arm 2 is now gated on `commandArmOwnedByCaller`,
-  true only at `~/.claude.json`, with the two `reportEntryCommand` call sites cited. New spec 9
-  pins the project-level `command` entry.
-- *`new URL(url).port || "80"` mis-reads a port-less `https` entry.* The default now comes from
-  the parsed protocol (443 / 80), with new spec 7.
-- *The port comparison mixes a string and a number.* Spelled `Number(...) !== mcpPort` in the Fix,
-  with the TS2367 note.
-- *Test 6 described a preserved `fix` the project arm does not have.* Reworded (now spec 8): the
-  project arm **gains** `brokenFileFix()`; `doctor.ts:1042-1043` passes one argument today.
-- *Done-when's "Both levels run one validator" is enforced by no test.* Softened to the
-  observable properties the specs actually assert (each condition warns at both levels, plus the
-  redaction and remedy splits), rather than a structural claim nothing checks.
-- *`apply.ts`'s `MCP_URL` was parked with "named in the PR body", against the two-person
-  fix-rather-than-file rule.* Not-in-scope now explains why bundling it is a design decision
-  rather than a small fix, and **requires the PR to file a tracked issue and cite the number
-  here**.
+- *The shared exported `evaluateTandemHttpEntry` with a six-field `opts` bag, and every change it
+  dragged into `checkMcpJson`* — the `commandArmOwnedByCaller` flag, the project level's new
+  `brokenFileFix()` / `portFix` strings, and specs 8 and 9. The issue asks for the **user-level**
+  check to validate as the project one does; refactoring the project level is a behaviour change
+  it did not request. **This makes the outstanding finding on spec 5 moot at the root**: with no
+  shared evaluator there is no wording-dependent arm to guard. Spec 5 still asserts the positive
+  pass message rather than a substring absence, per that finding's own fix.
+- *`defaultPortForProtocol`* — a new helper for a case that cannot change any verdict (a port-less
+  `https` entry mismatches the local MCP port either way). Arm 3 compares `parsedUrl.port` against
+  `String(mcpPort)` and reports `(none)`, which is smaller and has the string/number bug designed
+  out. The port-less-`https` spec went with it.
+- *The requirement to file an `MCP_URL` issue and cite its number in a user-facing `fix` string*,
+  and the `/#\d{3,}/` placeholder assertion that guarded it. The remedy now stands on its own
+  wording; the defect is recorded under `bryan`.
+- *The three round-by-round correction logs.* Their surviving decisions are inline: the redaction
+  rule and its stringified-set assertions, the computed `pathHasMcp`, the no-`setup --apply` port
+  remedy, and the both-env-vars stub.
 
-**Not adopted**
+**Kept**
 
-- *Bundle the `MCP_URL` fix into this PR* (the alternative offered by the same finding). `MCP_URL`
-  also feeds the desktop stdio entry's `TANDEM_URL` and the channel shim's, and the setup shell's
-  environment is not necessarily the server's — so choosing what it should read is a design call
-  that would land untested inside a doctor-only PR, against this wave's minimal-fix lesson. The
-  tracked-issue requirement above is taken instead.
-
-## Review corrections (round 2)
-
-**Adopted**
-
-- **BLOCKING** *The shared evaluator leaks the raw `~/.claude.json` `url` through its PASS arm.*
-  "Otherwise `pass` with the existing text" had no per-level seam, so the natural implementation
-  is the project wording `` `${label} tandem → ${url}` `` (`src/cli/doctor.ts:1045`) — and arms 3
-  and 4 do not fire on a healthy-shaped URL, so `http://tok:s3cret@127.0.0.1:3479/mcp?key=abc`
-  reaches it. Arm 5 now spells both messages out: the user level stays the byte-for-byte existing
-  `tandem registered in ~/.claude.json` (`:1209`) and never interpolates `url`. Spec 6 is
-  repointed onto a healthy-shaped entry carrying a credential payload and asserts the absence,
-  not just the status.
-- **BLOCKING** *Redaction was asserted only against `message`, while the per-check `data` bag
-  reaches `/api/diagnostics` and the prefilled issue body unscrubbed for credentials.*
-  `recordEvaluation` forwards `result.data` into `r.warn` (`src/cli/doctor.ts:411-422`) and
-  `redactUserPaths` collapses paths only (`diagnostics.ts:83-115`, and `:100-107` says it walks
-  the whole report *because* `data` is free-form). The redaction bullet now covers the whole
-  outcome — no `url` and no raw entry in `data` — and specs 4 and 6 assert over
-  `JSON.stringify(warn)` / `JSON.stringify(pass)` rather than `?.message`.
-- **BLOCKING** *Arm 4's `path=` prints a credential-carrying path component: `/mcp/<secret>`
-  satisfies the "pathname contains `/mcp`" condition the arm fires under.* The user-level message
-  now prints **no path value at all**: arm 4 is `type=` plus the two port numbers, and arm 3 is
-  `type=` plus `pathHasMcp=false`. Spec 2 is repointed onto `pathHasMcp=false`; spec 4 gains a
-  `http://example.invalid:9999/mcp/s3cret` case.
-- **BLOCKING** *The spec contradicted itself on the port-mismatch remedy — spec 8 pinned
-  `brokenFileFix()`, which ends in `setupApplyRemedy(cliAvailable())`
-  (`src/cli/doctor.ts:986-988`), for the one arm the Fix forbids it in* (raised twice). The Fix
-  now states `portFix` is supplied at **both** call sites and is never `brokenFileFix()`, gives
-  the project-level wording (edit `.mcp.json`'s `url`, which doctor already says at `:1077-1081`
-  that `setup --apply` does not manage), and spec 8 is split: arm 3 gains `brokenFileFix()`, arm 4
-  gets `portFix` plus `expect(warn?.fix).not.toMatch(/setup --apply/)`.
-- *`defaultPortForProtocol` was described as though it exists.* `grep -rn defaultPortForProtocol
-  src/` is empty; the Fix now marks it as a new module-private helper in `src/cli/doctor.ts`.
-- *The arm-4 warn is unclearable for a deliberately moved install — the same shape the spec cites
-  doctrine against.* Added as an explicit stated trade in the Fix, with the reason it is still the
-  right call, and arm 4's `fix` now cites the `MCP_URL` issue number so the user sees it too.
-- *Requiring a new issue for `MCP_URL` departs from the two-person fix-rather-than-file rule and
-  from this sweep's own Decision-B precedent, without saying so.* Not-in-scope now names both
-  rules and why this one is a design call with three consumers rather than a mechanical fix.
-- *Specs 1–9 extend a `HOME`-only describe while spec 10 needs both variables.* The Tests preamble
-  now requires `vi.stubEnv("USERPROFILE", home)` in that describe's `beforeEach` in the same
-  commit (`tests/cli/doctor.test.ts:2026-2031` stubs `HOME` alone today), and spec 10 refers to it
-  rather than restating a separate rule.
-
-**Not adopted**
-
-- None.
-
-## Review corrections (round 3)
-
-**Adopted**
-
-- **BLOCKING** *Spec 5 — the only guard on `commandArmOwnedByCaller` at the user level — asserted
-  the absence of a substring the Fix pins only for the PROJECT-level message, so it passes
-  vacuously with arm 2 dropped.* It now asserts the positive, wording-independent outcome: the
-  `user-mcp-config` results contain the pass whose message is `tandem registered in
-  ~/.claude.json` (`src/cli/doctor.ts:1209`), reachable only when the evaluator returns `null` for
-  a `command` entry, plus `reportEntryCommand`'s outcome. The `unexpected config` negative is
-  demoted to a secondary assertion.
-- *Spec 5 also did not pin that today's `pass` survives, so an implementation returning `null` and
-  emitting nothing passed every spec while deleting the outcome* (`recordEvaluation` is silent on
-  `null`, `src/cli/doctor.ts:411-413`). Covered by the same rewrite — the pass and
-  `reportEntryCommand`'s outcome are both required.
-- *Arm 4's project-level message was free to interpolate the raw `url`, widening the verbatim echo
-  onto exactly the population whose url is most likely to carry a credential.* The redaction bullet
-  now scopes the byte-for-byte project wording to **arm 3** and states that arm 4 never
-  interpolates `url` at either level, with the bounded-exposure note (`CWD_DEPENDENT_CHECKS` /
-  `filterDevRepoChecks`) as context rather than justification. Spec 8's arm-4 case gains
-  `expect(warn?.message).not.toContain(url)`.
-- *Arm 3's user-level message was specified as a fixed `pathHasMcp=false`, but arm 3 also fires on
-  `type !== "http"` with a good `/mcp` pathname — test 1 is exactly that entry, so the literal
-  would be a false statement in doctor output.* The field is now `pathHasMcp=<computed boolean>`,
-  and spec 1 asserts `pathHasMcp=true` alongside `type=stdio`.
-- *The `(#<MCP_URL issue>)` placeholder can ship in a user-facing remedy with nothing asserting the
-  substitution happened* (raised twice). Specs 3 and 8's arm-4 case gain
-  `expect(warn?.fix).toMatch(/#\d{3,}/)`, which reds while the placeholder is unresolved.
-- *The redaction Done-when covers every `user-mcp-config` outcome while specs 4 and 6 stringified a
-  single found result — `checkUserMcpConfig` emits several under that name
-  (`src/cli/doctor.ts:1206-1230`), so a sibling leak is invisible.* Both specs now assert over
-  `JSON.stringify(report.results.filter((x) => x.check === "user-mcp-config"))`.
-
-**Not adopted**
-
-- None.
+Type, path and port validation at the user level with the observed values named; the stdio
+carve-out; the redaction rule (the entries this fires on are exactly the ones whose url can carry a
+credential, and the check reaches a prefilled public issue body).

--- a/docs/reviews/2026-09-02-v1-review/tracks/specs/F-doctor-1807.md
+++ b/docs/reviews/2026-09-02-v1-review/tracks/specs/F-doctor-1807.md
@@ -32,19 +32,31 @@ and no shared evaluator is introduced** (see the scope cut).
   1. A non-empty string `command` → `null`. A stdio entry in `~/.claude.json` is a hand-edit or a
      plugin-managed shape, and `reportEntryCommand` (`:1213`) already owns it — warning
      "unexpected config" there is a regression dressed as a fix.
-  2. `type !== "http"`, or `url` missing / not parseable by `new URL()`, or the parsed pathname not
-     containing `/mcp` → message `` `~/.claude.json tandem: unexpected config — type=${type},
-     pathHasMcp=${bool}` `` (or `url=(unparsable)`), `fix` = `setupApplyRemedy(cliAvailable())`.
+  2. `type !== "http"`, or `url` missing / not parseable by `new URL()`, or **the parsed protocol
+     is not `http:`**, or the parsed pathname not containing `/mcp` → message
+     `` `~/.claude.json tandem: unexpected config — type=${type}, scheme=${scheme},
+     pathHasMcp=${bool}` ``, `fix` = `setupApplyRemedy(cliAvailable())`. On an unparsable url both
+     `scheme` and `pathHasMcp` render `(unparsable)`.
      **`pathHasMcp` is computed, not the constant `false`** — this arm also fires on a bad `type`
      with a perfectly good `/mcp` path (test 1), where a hardcoded `false` would be a false
-     statement in doctor output.
-  3. `parsedUrl.port !== String(mcpPort)` → message naming the observed port (or `(none)` when the
+     statement in doctor output. **`scheme` is named for the same reason**: `https://127.0.0.1:3479/mcp`
+     clears type, path, host and port while Claude Code's TLS handshake fails, and without the
+     scheme the warn reads `type=http, pathHasMcp=true` and names nothing actionable. Both `type`
+     and `scheme` go through `describeClampedValue` — see the redaction bullet below.
+  3. **The hostname is not one of `127.0.0.1` / `localhost` / `[::1]`** → message naming the
+     SHAPE (`url names a non-loopback host`), never the hostname, `fix` = a hand-edit pointing at
+     `127.0.0.1:<mcpPort>`. Host BEFORE port: a remote host on the *right* port is the one shape
+     this check must never certify, and reporting the port there names the wrong field.
+     `TAURI_HOSTNAME` is deliberately NOT in the set — this arm decides REACHABILITY, and the SDK's
+     `localhostHostValidation()` 403s every `/mcp` request carrying `Host: tauri.localhost` on a
+     default loopback bind.
+  4. `parsedUrl.port !== String(mcpPort)` → message naming the observed port (or `(none)` when the
      URL carries none) and `mcpPort`, `fix`: *edit the `url` in `~/.claude.json` to port `<mcpPort>`,
      or unset `TANDEM_MCP_PORT` and restart Tandem*. **Compare the string form and treat a
      port-less URL as a mismatch** — the entry must name Tandem's MCP port explicitly; that is what
      kills the `URL.port`-is-a-string bug (`"3479" !== 3479` is always true) without a
      `defaultPortForProtocol` helper.
-  4. Otherwise `null`.
+  5. Otherwise `null`.
 - **The port warn must never emit `setupApplyRemedy`.** `MCP_URL` is hardcoded, so `setup --apply`
   re-writes 3479 and the warn re-fires forever — the dead-end-remedy defect this file has already
   been corrected for twice (`src/cli/doctor.ts:1163-1190`, and the doctrine by name at
@@ -56,7 +68,14 @@ and no shared evaluator is introduced** (see the scope cut).
   prefills a public issue body. The only scrubber downstream, `redactUserPaths`
   (`diagnostics.ts:83-115`), collapses paths and knows nothing about URL userinfo or a query token
   — and `r.warn` forwards `data` verbatim, so `r.warn(msg, fix, { url })` would satisfy every
-  message-only assertion and still ship the credential. `type` stays verbatim (enum-shaped).
+  message-only assertion and still ship the credential. **`type` is NOT echoed verbatim**: arm 2
+  fires precisely when the value is not enum-shaped, so `describeClampedValue` renders anything
+  outside `/^[A-Za-z0-9_-]{1,32}$/` as `(unexpected)` — a `\r\x1b[2K` value repaints doctor's own
+  warn line as a pass, a bare `\n` forges a second result line, and the value is length-unbounded
+  on the way to the Report-a-bug prefill. The scheme takes the same renderer: it comes off a
+  *parsed* `URL` so control bytes are impossible, but one renderer keeps the two fields from
+  drifting apart on the rule that governs both. The scheme is the only part of the url that is
+  ever named, and it can carry no secret — it is neither host, userinfo, path nor query.
 - `warn`, never `fail` — parity with the twin; `tandem doctor` must not start exiting 1 on a
   machine whose tools arrive via the plugin.
 
@@ -109,11 +128,12 @@ Windows.
 
 ## Done when
 
-A wrong `type`, a URL without `/mcp`, and a port that disagrees with the probed MCP port each warn
-at the user level; no `user-mcp-config` outcome — warn or pass, in `message`, `fix` or `data` —
-echoes the raw `url` or any part of its path; the port warn's `fix` does not name `setup --apply`;
-a stdio entry still passes and is left to `reportEntryCommand`; a healthy HTTP entry passes;
-typecheck + the CLI suite green.
+A wrong `type`, a non-`http:` scheme, a URL without `/mcp`, a non-loopback host, and a port that
+disagrees with the probed MCP port each warn at the user level; no `user-mcp-config` outcome —
+warn or pass, in `message`, `fix` or `data` — echoes the raw `url`, its hostname or any part of
+its path; a non-enum-shaped `type` renders `(unexpected)` rather than reaching the output; the
+port and host warns' `fix` does not name `setup --apply`; a stdio entry still passes and is left
+to `reportEntryCommand`; a healthy HTTP entry passes; typecheck + the CLI suite green.
 
 ## Not in scope
 
@@ -166,9 +186,33 @@ credential, and the check reaches a prefilled public issue body).
 ## Review corrections (post-cut)
 
 - **Spec 8 (port-less URL) added.** The seven specs left after the scope cut all carried an
-  explicit port, so arm 3's stated requirement — treat a missing `URL.port` as a mismatch and
-  report `(none)` — was pinned by nothing, and the natural `if (parsedUrl.port && …)` spelling
+  explicit port, so the port arm's stated requirement — treat a missing `URL.port` as a mismatch
+  and report `(none)` — was pinned by nothing, and the natural `if (parsedUrl.port && …)` spelling
   passed all of them while leaving `http://127.0.0.1/mcp` (port 80) green. This is **not** the
   port-less-`https` spec the cut removed: that one existed to exercise `defaultPortForProtocol`,
   which is still gone. This one exercises the `(none)` branch the cut's own replacement design
   introduced.
+
+## Review corrections (rounds 2–3, implementation)
+
+Three review rounds against the implementation changed `validateUserTandemEntry`'s behaviour, and
+the sections above are written to match what shipped. Recorded here rather than left implicit,
+because each one was a *pass on a config Claude Code cannot use* — the defect #1807 names — and
+the Tauri entry below was introduced by a well-meant arm added to prevent exactly that.
+
+- **The non-loopback host arm (new arm 3).** A `http://attacker.example:3479/mcp` entry cleared
+  every other arm, so doctor certified green the one shape where Claude Code would send
+  `tandem_getTextContent` output and `tandem_edit` payloads to somebody else's machine.
+- **`TAURI_HOSTNAME` removed from the loopback set.** It was added on the grounds that the desktop
+  WebView's own origin is that name. `server.ts` passes `allowedHosts` — the only list
+  `tauri.localhost` is on — solely when a LAN IP resolved; on a default loopback bind the SDK
+  installs `localhostHostValidation()`, whose allowlist is exactly `localhost` / `127.0.0.1` /
+  `[::1]`, and every `/mcp` request carrying `Host: tauri.localhost` is answered `403 Invalid
+  Host`. The WebView origin is a CORS/Origin concern, not an MCP url host.
+- **The scheme half of arm 2, and `scheme=` in its message.** Tandem's MCP server is plaintext
+  HTTP on loopback, so `https://127.0.0.1:3479/mcp` passed type, path, host and port while the TLS
+  handshake failed and no `tandem_*` tool ever appeared.
+- **`describeClampedValue` for `type` and `scheme`.** The spec's original "`type` stays verbatim
+  (enum-shaped)" was false on the one branch that prints it: arm 2 fires precisely when the value
+  is *not* enum-shaped, and `~/.claude.json` is arbitrary JSON from disk that reaches
+  `/api/diagnostics` and the public Report-a-bug prefill unbounded in length.

--- a/docs/reviews/2026-09-02-v1-review/tracks/specs/F-doctor-1807.md
+++ b/docs/reviews/2026-09-02-v1-review/tracks/specs/F-doctor-1807.md
@@ -44,9 +44,14 @@ and no shared evaluator is introduced** (see the scope cut).
      scheme the warn reads `type=http, pathHasMcp=true` and names nothing actionable. Both `type`
      and `scheme` go through `describeClampedValue` — see the redaction bullet below.
   3. **The hostname is not one of `127.0.0.1` / `localhost` / `[::1]`** → message naming the
-     SHAPE (`url names a non-loopback host`), never the hostname, `fix` = a hand-edit pointing at
-     `127.0.0.1:<mcpPort>`. Host BEFORE port: a remote host on the *right* port is the one shape
-     this check must never certify, and reporting the port there names the wrong field.
+     SHAPE (`url names a non-loopback host`), never the hostname, and stating the condition
+     truthfully: the server *listens on loopback unless it was started with `TANDEM_BIND_HOST`*.
+     `fix` = a hand-edit pointing at `127.0.0.1:<mcpPort>`, prefixed with that same condition
+     (*if Tandem was not started with `TANDEM_BIND_HOST`*). Doctor runs in the user's shell, which
+     need not carry the server's env, so it does not pretend to know the bind host — it warns
+     either way and lets the reader apply the condition. Host BEFORE port: a remote host on the
+     *right* port is the one shape this check must never certify, and reporting the port there
+     names the wrong field.
      `TAURI_HOSTNAME` is deliberately NOT in the set — this arm decides REACHABILITY, and the SDK's
      `localhostHostValidation()` 403s every `/mcp` request carrying `Host: tauri.localhost` on a
      default loopback bind.
@@ -216,3 +221,15 @@ the Tauri entry below was introduced by a well-meant arm added to prevent exactl
   (enum-shaped)" was false on the one branch that prints it: arm 2 fires precisely when the value
   is *not* enum-shaped, and `~/.claude.json` is arbitrary JSON from disk that reaches
   `/api/diagnostics` and the public Report-a-bug prefill unbounded in length.
+
+## Review corrections (post-ship)
+
+- **The non-loopback warn no longer says "loopback-only".** That sentence was false under
+  `TANDEM_BIND_HOST` (`docs/configuration.md`; `src/server/bind-check.ts`; `server.ts` puts the
+  resolved LAN IP into the SDK's `allowedHosts`), so a user who deliberately bound to the LAN and
+  pointed `~/.claude.json` at that IP got a warn on a working setup whose `fix` broke it. Doctor
+  runs in the user's shell, which need not carry the server's env, so it cannot know the bind host
+  and does not pretend to: the arm stays a warn, the message reads *listens on loopback unless it
+  was started with `TANDEM_BIND_HOST`*, and the `fix` is prefixed with the same condition. The
+  no-url-interpolation rule is untouched — neither string names the hostname. The LAN-address spec
+  pins the new wording and the absence of the old one.

--- a/docs/reviews/2026-09-02-v1-review/tracks/specs/F-doctor-1807.md
+++ b/docs/reviews/2026-09-02-v1-review/tracks/specs/F-doctor-1807.md
@@ -69,12 +69,24 @@ nothing says so. **That also settles what arm 4's remedy may say; see below.**
 
 - **The message is redacted at the user level and verbatim at the project level, and the two
   deliberately differ.** `opts.redactUrl` is what splits them:
-  - **`.mcp.json` (`redactUrl: false`)** keeps today's wording byte-for-byte:
+  - **`.mcp.json` (`redactUrl: false`)** keeps today's wording byte-for-byte **for arm 3 only**:
     `` `${label} tandem: unexpected config — type=${type}, url=${url}` ``.
+  - **Arm 4's message never interpolates `url`, at EITHER level.** The two port numbers are the
+    whole finding, and arm 4 fires only on urls that already passed the shape checks — a
+    `type: "http"`, `/mcp`-terminated url naming a non-default port is exactly the hosted or remote
+    endpoint most likely to carry a credential, so widening today's verbatim project-level echo
+    onto that population is a new exposure rather than preserved wording. The exposure would be
+    bounded (`mcp-json` is in `CWD_DEPENDENT_CHECKS`, `src/cli/doctor.ts:455-461`, and
+    `filterDevRepoChecks` strips it from `/api/diagnostics` and `tandem_diagnostics`,
+    `src/server/mcp/routes/diagnostics.ts:39,57`), which is why it is a message rule rather than a
+    second `redactUrl` level — but "bounded to the CLI terminal" is not a reason to print it.
   - **`~/.claude.json` (`redactUrl: true`)** never interpolates the raw `url`, **and never
     interpolates the pathname either**:
-    - Arm 3 prints `type=<observed>` plus `pathHasMcp=false` (or, for a URL `new URL()` rejects,
-      the literal `url=(unparsable)`). **Not `path=<value>`.** A path segment is a standard
+    - Arm 3 prints `type=<observed>` plus `pathHasMcp=<computed boolean>` (or, for a URL
+      `new URL()` rejects, the literal `url=(unparsable)`). **The boolean is computed, not the
+      constant `false`**: arm 3 also fires on `type !== "http"` with a perfectly good `/mcp`
+      pathname (test 1 is exactly that entry), where a hardcoded `pathHasMcp=false` would be a
+      false statement in doctor output. **Not `path=<value>`.** A path segment is a standard
       credential carrier for exactly this population — hosted MCP endpoints commonly embed the
       key as `https://host/v1/<token>/mcp` — and `pathHasMcp=false` names the finding, which the
       value does not add to. The `fix` string is what tells the user what to do.
@@ -169,34 +181,55 @@ on Windows too and spec 10 — which runs the whole doctor through `runDoctorCli
 HOME via `mkdtempSync`, `vi.unstubAllEnvs()` in `afterEach` — **never the real HOME**:
 
 1. `{ tandem: { type: "stdio", url: "http://127.0.0.1:3479/mcp" } }` → `user-mcp-config` warn whose
-   message contains `type=stdio`. Kills "validate url only".
+   message contains `type=stdio` **and `pathHasMcp=true`**. Kills "validate url only", and pins
+   `pathHasMcp` as computed rather than a constant — this entry's pathname does contain `/mcp`.
 2. `{ tandem: { type: "http", url: "http://127.0.0.1:3479/" } }` → warn naming `pathHasMcp=false`,
    and the message must **not** contain the raw `http://127.0.0.1:3479/` (nor a `path=` value).
    Kills "validate type only", and pins the redaction's shape-not-value rule for arm 3.
 3. `{ tandem: { type: "http", url: "http://127.0.0.1:9999/mcp" } }` → warn naming **9999 and
    3479**. Kills a validator that accepts any `/mcp` URL — the issue's headline case. Plus
    `expect(warn?.fix).not.toMatch(/setup --apply/)`, mirroring `tests/cli/doctor.test.ts:2057`:
-   the dead-end remedy is the half that ships silently.
-4. **Redaction, discriminating cases — asserted over the WHOLE outcome, not `message`.** Two
-   entries, each `→` a warn that names 9999 and whose `JSON.stringify(warn)` contains **none** of
-   the credential strings. `JSON.stringify`, not `warn?.message`: it covers `message`, `fix` and
-   the `data` bag in one non-sniffable check, and `data` is the channel a message-only assertion
-   misses entirely (see the redaction bullet).
+   the dead-end remedy is the half that ships silently. **And
+   `expect(warn?.fix).toMatch(/#\d{3,}/)`** — `portFix`'s wording ends in the `MCP_URL` issue
+   number, which is filed during this PR (see Not in scope). Nothing else would catch a literal
+   `(#<MCP_URL issue>)` placeholder shipping in a user-facing remedy.
+4. **Redaction, discriminating cases — asserted over EVERY `user-mcp-config` outcome, not one
+   found result and not `message`.** Two entries, each `→` a warn that names 9999, with the
+   absence asserted over
+   `JSON.stringify(report.results.filter((x) => x.check === "user-mcp-config"))`.
+   `JSON.stringify`, not `warn?.message`: it covers `message`, `fix` and the `data` bag in one
+   non-sniffable check, and `data` is the channel a message-only assertion misses entirely (see the
+   redaction bullet). **The filter, not a single `find`:** `checkUserMcpConfig` emits several
+   results under that check name (`src/cli/doctor.ts:1206-1230` — the tandem outcome, then
+   `reportEntryCommand`, then the two channel outcomes), so a leak in a sibling outcome is
+   invisible to a one-result assertion.
    - `{ type: "http", url: "http://tok:s3cret@example.invalid:9999/mcp?key=abc" }` → contains
      neither `s3cret` nor `key=abc` nor the raw url. Kills a copy of the twin's verbatim `url=`
      interpolation at the level that reaches a prefilled public issue body.
    - `{ type: "http", url: "http://example.invalid:9999/mcp/s3cret" }` → contains neither
      `s3cret` nor the raw url. Kills arm 4 printing `path=`, which is a live token carrier
      precisely because arm 4 requires `/mcp` in the pathname.
-5. `{ tandem: { command: "/abs/node", args: [...] } }` → **no** `unexpected config` warn from the
-   new validator. Kills arm 2 being dropped at the user level.
+5. `{ tandem: { command: "/abs/node", args: [...] } }` → **assert the POSITIVE, wording-independent
+   outcome**: the `user-mcp-config` results **contain a pass whose message is
+   `tandem registered in ~/.claude.json`** (`src/cli/doctor.ts:1209`), and `reportEntryCommand`'s
+   own outcome for the stdio entry still appears. That pass is reachable only when the evaluator
+   returns `null` for a `command` entry, so it reds if arm 2 is made unconditional — and it also
+   reds on an implementation that returns `null` **and emits nothing at all**, which today's
+   `recordEvaluation` (`src/cli/doctor.ts:411-413`, silent on `null`) makes easy to ship. A bare
+   "no `unexpected config` warn" assertion catches neither: the Fix pins that substring only for
+   the **project**-level message (`redactUrl: false`), so the user-level warn is free to be worded
+   differently and pass vacuously with arm 2 dropped. Keep
+   `expect(JSON.stringify(userResults)).not.toContain("unexpected config")` as a secondary
+   assertion only.
 6. **The healthy entry passes AND says nothing about the url.** Use a healthy-*shaped* entry that
    carries a credential payload: `{ type: "http", url: "http://tok:s3cret@127.0.0.1:3479/mcp?key=abc" }`
-   → a `user-mcp-config` **pass** whose `JSON.stringify` contains neither `s3cret` nor `key=abc`
-   nor the raw url — the pass message stays the existing `tandem registered in ~/.claude.json`.
-   Asserting only `status === "pass"` is non-discriminating on exactly the property this arm
-   exists to establish. Keep a plain `…:3479/mcp` pass assertion too, so a future over-eager arm
-   reds every working install.
+   → a `user-mcp-config` **pass** whose message is the existing `tandem registered in
+   ~/.claude.json`, with the absence asserted over
+   `JSON.stringify(report.results.filter((x) => x.check === "user-mcp-config"))` — neither
+   `s3cret` nor `key=abc` nor the raw url, in **any** outcome under that check name (same
+   sibling-outcome reason as spec 4). Asserting only `status === "pass"` is non-discriminating on
+   exactly the property this arm exists to establish. Keep a plain `…:3479/mcp` pass assertion too,
+   so a future over-eager arm reds every working install.
 7. Port-less `https`: `{ tandem: { type: "http", url: "https://example.invalid/mcp" } }` warns
    naming **443**, not 80. Kills the hardcoded `|| "80"` default.
 8. Project-level twin, in the `checkMcpJson` describe. Two entries, and which one gets which
@@ -206,10 +239,12 @@ HOME via `mkdtempSync`, `vi.unstubAllEnvs()` in `afterEach` — **never the real
      **gains `brokenFileFix()`**. Rewriting the entry genuinely fixes this one.
    - **Arm 4** (the same wrong-port entry) → warn whose `fix` is the project-level `portFix`,
      naming editing `.mcp.json`'s `url`, plus
-     `expect(warn?.fix).not.toMatch(/setup --apply/)` — the assertion spec 3 already carries at
-     the user level. `brokenFileFix()` ends in `setupApplyRemedy(cliAvailable())`
-     (`src/cli/doctor.ts:986-988`), so pinning it here would ship and lock in the dead-end remedy
-     the Fix section forbids.
+     `expect(warn?.fix).not.toMatch(/setup --apply/)` and `expect(warn?.fix).toMatch(/#\d{3,}/)` —
+     both assertions spec 3 already carries at the user level. `brokenFileFix()` ends in
+     `setupApplyRemedy(cliAvailable())` (`src/cli/doctor.ts:986-988`), so pinning it here would
+     ship and lock in the dead-end remedy the Fix section forbids. **And
+     `expect(warn?.message).not.toContain(url)`** — arm 4's message names the two ports and never
+     the url, at this level too (see the redaction bullet).
 9. **Project-level `command` entry** — the arm-2 regression guard. A `.mcp.json` whose `tandem`
    entry is `{ command: "/abs/node", args: [] }` still produces an `mcp-json` **warn** and must
    NOT produce a `pass` containing `undefined`. Without `commandArmOwnedByCaller` this spec is
@@ -341,6 +376,43 @@ issue covers it. File one rather than commenting on an unrelated one.
   now requires `vi.stubEnv("USERPROFILE", home)` in that describe's `beforeEach` in the same
   commit (`tests/cli/doctor.test.ts:2026-2031` stubs `HOME` alone today), and spec 10 refers to it
   rather than restating a separate rule.
+
+**Not adopted**
+
+- None.
+
+## Review corrections (round 3)
+
+**Adopted**
+
+- **BLOCKING** *Spec 5 — the only guard on `commandArmOwnedByCaller` at the user level — asserted
+  the absence of a substring the Fix pins only for the PROJECT-level message, so it passes
+  vacuously with arm 2 dropped.* It now asserts the positive, wording-independent outcome: the
+  `user-mcp-config` results contain the pass whose message is `tandem registered in
+  ~/.claude.json` (`src/cli/doctor.ts:1209`), reachable only when the evaluator returns `null` for
+  a `command` entry, plus `reportEntryCommand`'s outcome. The `unexpected config` negative is
+  demoted to a secondary assertion.
+- *Spec 5 also did not pin that today's `pass` survives, so an implementation returning `null` and
+  emitting nothing passed every spec while deleting the outcome* (`recordEvaluation` is silent on
+  `null`, `src/cli/doctor.ts:411-413`). Covered by the same rewrite — the pass and
+  `reportEntryCommand`'s outcome are both required.
+- *Arm 4's project-level message was free to interpolate the raw `url`, widening the verbatim echo
+  onto exactly the population whose url is most likely to carry a credential.* The redaction bullet
+  now scopes the byte-for-byte project wording to **arm 3** and states that arm 4 never
+  interpolates `url` at either level, with the bounded-exposure note (`CWD_DEPENDENT_CHECKS` /
+  `filterDevRepoChecks`) as context rather than justification. Spec 8's arm-4 case gains
+  `expect(warn?.message).not.toContain(url)`.
+- *Arm 3's user-level message was specified as a fixed `pathHasMcp=false`, but arm 3 also fires on
+  `type !== "http"` with a good `/mcp` pathname — test 1 is exactly that entry, so the literal
+  would be a false statement in doctor output.* The field is now `pathHasMcp=<computed boolean>`,
+  and spec 1 asserts `pathHasMcp=true` alongside `type=stdio`.
+- *The `(#<MCP_URL issue>)` placeholder can ship in a user-facing remedy with nothing asserting the
+  substitution happened* (raised twice). Specs 3 and 8's arm-4 case gain
+  `expect(warn?.fix).toMatch(/#\d{3,}/)`, which reds while the placeholder is unresolved.
+- *The redaction Done-when covers every `user-mcp-config` outcome while specs 4 and 6 stringified a
+  single found result — `checkUserMcpConfig` emits several under that name
+  (`src/cli/doctor.ts:1206-1230`), so a sibling leak is invisible.* Both specs now assert over
+  `JSON.stringify(report.results.filter((x) => x.check === "user-mcp-config"))`.
 
 **Not adopted**
 

--- a/docs/reviews/2026-09-02-v1-review/tracks/specs/F-doctor-1811.md
+++ b/docs/reviews/2026-09-02-v1-review/tracks/specs/F-doctor-1811.md
@@ -24,7 +24,7 @@ never mentions it. That is the fix here, and it is the shape the track file reco
 
 ## Fix
 
-- **New shared leaf `src/shared/integrations/tandem-plugin.ts`** (~30 lines), sibling of the
+- **New shared leaf `src/shared/integrations/tandem-plugin.ts`** (~35 lines), sibling of the
   existing `client-config-paths.ts` — whose own doctrine comment ("Path from the shared leaf, so
   doctor inspects the file `detectTargets` writes rather than a second hand-maintained copy of the
   same rule") is the precedent for putting the predicate in one place instead of duplicating it:
@@ -34,20 +34,52 @@ never mentions it. That is the fix here, and it is the shape the track file reco
     a deliberately disabled plugin — and match any marketplace suffix, because
     `docs/spikes/plugin-delivery.md` recommends a local one and a hardcoded
     `tandem@tandem-editor` in a remedy hands those users a command that errors.
-  - `detectEnabledTandemPlugin(opts: { homeOverride?: string } = {}): string | null` — resolves
-    `<home>/.claude/settings.json`, **refuses a UNC/device path first via
-    `rejectUnsafeWindowsPrefix` from `src/shared/windows-path-safety.ts`** (#1417: reading one
-    performs the SMB handshake that leaks an NTLM hash — the screen must precede the read, not
-    wrap it), then `readFileSync` + `JSON.parse` inside a total `try/catch`, and returns
+  - `detectEnabledTandemPlugin(opts: { homeOverride?: string } = {}): string | null`.
+
+    **Home resolution is pinned, because the production call site passes no argument and the
+    two spellings in this repo do not agree.** Use
+    `opts.homeOverride ?? process.env.HOME ?? process.env.USERPROFILE ?? homedir()` — the shape
+    `checkTandemPlugin` (`src/cli/doctor.ts:1972`) and `checkUserMcpConfig` (`:1107`) already
+    use. Its siblings in `apply.ts` (`:754`, `:2066`, `:2127`) use `opts.homeOverride ??
+    homedir()`, and `homedir()` reads `USERPROFILE` on Windows and ignores `HOME` — so a test
+    that stubs `HOME` alone would silently read the operator's real profile on the platform this
+    wave runs on. Writing the env reads explicitly is what makes both stubs work.
+
+    **Two UNC screens, not one — the derived path alone is not enough.** Screen the raw `home`
+    value **before** any `join`, in `homeIsUnsafe`'s shape
+    (`home !== "" && rejectUnsafeWindowsPrefix(home) !== null` — `rejectUnsafeWindowsPrefix` from
+    `src/shared/windows-path-safety.ts`), then resolve `<home>/.claude/settings.json` and let the
+    read's own screen stand as a backstop. `src/cli/doctor.ts:654-684` records the measurement
+    this comes from: of the fourteen spellings in `tests/helpers/unc-fixtures.ts`, four pure
+    forward-slash forms "collapse to a path this guard then accepts once `path.posix.join` has
+    run". A derived-path-only screen therefore passes those rows on ubuntu — the only platform
+    `check` runs — *because the path stopped being dangerous, not because anything screened it*:
+    the #1529 shape, a non-discriminating test that reads exactly like a pass. #1417 is the
+    underlying rule (reading a UNC path performs the SMB handshake that leaks an NTLM hash), so
+    the screen must precede the read, not wrap it.
+
+    Then `readFileSync` + `JSON.parse` inside a total `try/catch`, returning
     `findEnabledTandemPluginKey(parsed.enabledPlugins)`. Every failure → `null`: absence is not
     evidence, and this must never make `setup --apply` fail.
+
+    **On the unfenced-reader fence.** `tests/cli/doctor-path-safety.test.ts:694-717` keeps the
+    unfenced `readJson` away from Claude configs, and it reads `src/cli/doctor.ts` only
+    (`:695`), so a reader in `src/shared/integrations/` is invisible to it. The leak class it
+    guards is structurally absent here — this leaf's whole return type is `string | null`, it
+    carries no `reason` field and never surfaces parse detail, which is exactly why
+    `readClaudeConfig` exists separately (`src/cli/doctor.ts:595-604`). Reusing
+    `readClaudeConfig` is not available: it lives in `src/cli/`, and `src/shared/` importing
+    upward inverts the layering. So **extend the fence's scan set instead**: make its `SOURCE`
+    the concatenation of `src/cli/doctor.ts` and `src/shared/integrations/tandem-plugin.ts`, so a
+    future `readJson(join(home, ".claude", "settings.json"))` added to the leaf reds the fence
+    rather than shipping unseen. Say so in the fence's comment.
 - **`src/cli/doctor.ts`:** `evaluateTandemPlugin` calls `findEnabledTandemPluginKey(input.enabledPlugins)`
   in place of its inline `Object.entries(...).find(...)`. One line, no behaviour change — it exists
   so the two surfaces cannot drift. Doctor keeps its own reader, its own `homeIsUnsafe` screen and
   its own reporting; it does **not** import `detectEnabledTandemPlugin`.
 - **`src/cli/setup.ts`, `applySetup`:** call `detectEnabledTandemPlugin()` once, immediately before
-  `console.error("Detecting Claude installations...")`, and when it returns a key print one
-  notice to stderr (setup's whole output is stderr):
+  `console.error("Detecting Claude installations...")` (`src/cli/setup.ts:116`), and when it
+  returns a key print one notice to stderr (setup's whole output is stderr):
   `The Tandem plugin (<key>) is installed and already provides the tandem_* tools. Writing this
   config too makes every tool appear twice — keep one: claude plugin uninstall <key>`.
 - **The write still happens.** `--apply` is the scriptable, non-interactive path whose contract is
@@ -55,33 +87,62 @@ never mentions it. That is the fix here, and it is the shape the track file reco
   no output saying why nothing was written. Warn, do not skip. (Assumption; the issue's own
   suggestion offers skipping, the track file's taken shape says warn.)
 
-Rules that bite: **never against the real HOME** — the notice reads `~/.claude/settings.json`, so
-every test uses `homeOverride` or a scratch `HOME`/`USERPROFILE`. No config *writer* is added
-(#1599's bound and `tests/docs/config-writer-set-claims.test.ts` count durable write sites; this
-is a read). No new `/api` route, no MCP tool, no skill edit.
+Rules that bite: **never against the real HOME** — see the Tests section, which pins *how* rather
+than only asserting the rule. No config *writer* is added (#1599's bound and
+`tests/docs/config-writer-set-claims.test.ts` count durable write sites; this is a read). No new
+`/api` route, no MCP tool, no skill edit.
 
 ## Tests
 
-- `tests/shared/integrations/tandem-plugin.test.ts` (new): `findEnabledTandemPluginKey` returns the
-  key for `{"tandem@tandem-editor": true}`; `null` for `{"tandem@x": false}` (kills a truthiness
-  check); `null` for `{"other@y": true}`; `null` for `null`/`undefined`/`{}`; returns the key for a
-  non-default marketplace `{"tandem@local-marketplace": true}` (kills a hardcoded suffix).
-  `detectEnabledTandemPlugin({ homeOverride })` against a temp home: absent file → `null`;
-  malformed JSON → `null` (no throw); `enabledPlugins` present → the key.
-- `tests/cli/setup.test.ts` (or `run-setup-apply.test.ts`, whichever already drives `applySetup`
-  with a scratch home): with a settings.json enabling `tandem@tandem-editor`, `--apply` prints a
-  notice containing `plugin uninstall` **and still writes the MCP entry** — the second assertion is
-  the discriminating one, killing a fix that "helpfully" skips the write. With `false`, and with no
-  settings.json at all, no notice is printed (kills a check that fires for every user).
+The two levels are tested through different seams, and the split is the point: the **leaf's own
+behaviour** (home resolution, UNC screen, JSON handling) is unit-tested with an explicit
+`homeOverride`; the **`applySetup` wiring** (is it called, is the notice printed, is the write
+still made) is tested with the module mocked, so no real filesystem read happens at all.
+
+- `tests/shared/integrations/tandem-plugin.test.ts` (new):
+  - `findEnabledTandemPluginKey` returns the key for `{"tandem@tandem-editor": true}`; `null` for
+    `{"tandem@x": false}` (kills a truthiness check); `null` for `{"other@y": true}`; `null` for
+    `null`/`undefined`/`{}`; returns the key for a non-default marketplace
+    `{"tandem@local-marketplace": true}` (kills a hardcoded suffix).
+  - `detectEnabledTandemPlugin({ homeOverride })` against a temp home: absent file → `null`;
+    malformed JSON → `null` (no throw); `enabledPlugins` present → the key.
+  - **Home resolution**, with no `homeOverride`: stub `HOME` to a temp dir carrying the settings
+    file → the key; then unstub `HOME`, stub `USERPROFILE` to it → the key. Both stubs, because
+    only one of them survives on each platform. `vi.unstubAllEnvs()` in `afterEach`.
+  - **UNC table**, driven over `NETWORK_PATHS` from `tests/helpers/unc-fixtures.ts` rather than a
+    single `\\\\host\\share` case: for every row, `detectEnabledTandemPlugin({ homeOverride: p })`
+    must make **no filesystem call**. Per that file's own standing rule, spy on `readFileSync` and
+    assert `not.toHaveBeenCalled()` — asserting the `null` return proves nothing, because the
+    unscreened code returns `null` too (the syscall throws).
+- `tests/cli/run-setup-apply.test.ts` — **this file, not `setup.test.ts`.** Add
+  `vi.mock("../../src/shared/integrations/tandem-plugin.js", …)` alongside the existing
+  `apply.js` mock (`:13-30`), stubbing `detectEnabledTandemPlugin`. That file mocks only
+  `apply.js` today, so an unmocked call into a *different* module would `readFileSync` the real
+  `homedir()/.claude/settings.json` in all four of its existing `runSetup({ apply: true })` specs
+  — the #1894 hazard class this group is explicitly told to avoid, and it would make the negative
+  specs pass or fail by machine. Specs:
+  - stub returns `"tandem@tandem-editor"` → `--apply` prints a notice containing
+    `plugin uninstall` **and still calls `applyConfig`** — the second assertion is the
+    discriminating one, killing a fix that "helpfully" skips the write.
+  - stub returns `null` → no notice (kills a check that fires for every user).
+
+  There is deliberately **no** `applySetup` spec in `tests/cli/setup.test.ts`: nothing there
+  drives `runSetup({ apply: true })` today (`:1034`, `:1044` drive `runSetup()` and
+  `runSetup({ apply: false, force: true })`), and that file states at `run-setup-apply.test.ts:9-11`
+  that it exercises the **real** `apply.js` — so adding an `--apply` driver there would run the
+  real `detectTargets`/`applyConfig` against the real home. Do not put the notice specs there.
 - `tests/cli/doctor.test.ts`: keep/add a pin that `evaluateTandemPlugin({ enabledPlugins:
   {"tandem@tandem-editor": true}, wizardTandemEntry: true })` still yields the duplication `warn`
   whose `fix` names `claude plugin uninstall tandem@tandem-editor` — the refuted half is a working
   behaviour with no test of its own, and the refactor above touches its key-finding line.
+- `tests/cli/doctor-path-safety.test.ts`: extend the unfenced-reader fence's `SOURCE` to include
+  the new leaf, per the Fix.
 
 ## Done when
 
 `setup --apply` on a machine with the plugin installed says so and names the remedy before it
-writes; the predicate exists once; doctor's existing duplication warn is pinned; typecheck + the
+writes; the predicate exists once; the leaf refuses every `NETWORK_PATHS` spelling before any
+syscall; no test reads a real home; doctor's existing duplication warn is pinned; typecheck + the
 CLI and shared suites green. The PR body records the refutation with the `git show` citation.
 
 ## Not in scope
@@ -89,3 +150,44 @@ CLI and shared suites green. The PR body records the refutation with the `git sh
 A doctor `--fix` flag (a new CLI surface; not in the taken shape). README / wizard copy (docs
 drift is #1821 / the J2 group). Making `setup --apply` skip the MCP write. Anything about the
 plugin's own npx pin — that is #1790.
+
+## Files touched
+
+`src/shared/integrations/tandem-plugin.ts` (new), `src/cli/doctor.ts`, `src/cli/setup.ts`,
+`tests/shared/integrations/tandem-plugin.test.ts` (new), `tests/cli/run-setup-apply.test.ts`,
+`tests/cli/doctor.test.ts`, `tests/cli/doctor-path-safety.test.ts`.
+
+## Review corrections (round 1)
+
+**Adopted**
+
+- *`detectEnabledTandemPlugin()` is called from `applySetup` with no home seam, so the new read
+  hits the operator's real `~/.claude/settings.json` in every existing `run-setup-apply` spec and
+  the negative specs become machine-dependent* (raised twice). The Tests section now names the
+  seam explicitly: add `vi.mock("../../src/shared/integrations/tandem-plugin.js")` alongside the
+  existing `apply.js` mock in `tests/cli/run-setup-apply.test.ts`, with the notice specs asserted
+  against the stub. The `"(or setup.test.ts, whichever already drives applySetup with a scratch
+  home)"` parenthetical is deleted and replaced with a paragraph saying why nothing there does and
+  why the specs must not move there.
+- *No specified home-resolution order, and `homedir()` ignores `HOME` on Windows.* Pinned to
+  `opts.homeOverride ?? process.env.HOME ?? process.env.USERPROFILE ?? homedir()` with the reason
+  and the two conflicting in-repo spellings cited; new leaf specs stub `HOME` and `USERPROFILE`
+  separately.
+- *The UNC screen was specified on the derived path, not the raw home — the measured POSIX blind
+  spot `homeIsUnsafe` exists for* (raised twice). Now spelled as two screens, raw-then-backstop,
+  in `homeIsUnsafe`'s shape, with the `doctor.ts:654-684` measurement and the #1529 shape cited.
+  The single-case UNC spec is replaced by a table over `NETWORK_PATHS`, asserting the **syscall**
+  is not made rather than the return value — the standing rule in `tests/helpers/unc-fixtures.ts`.
+- *A second unfenced JSON reader of a Claude config, outside the file the existing fence scans.*
+  Fix now states which of the two options is taken and why: `readClaudeConfig` cannot be reused
+  (`src/shared/` importing from `src/cli/` inverts the layering), the `reason`-leak class is
+  structurally absent from a `string | null` leaf, and the fence's `SOURCE` set is extended to
+  include the new module so a future `readJson` there reds it. Added to Tests and Files touched.
+
+**Not adopted**
+
+- *Thread `homeOverride` through `applySetup` as the seam* (the alternative offered by the same
+  finding). Mocking the module in `run-setup-apply.test.ts` is strictly safer — with the module
+  mocked no filesystem read happens at all, so the negative specs cannot depend on machine state
+  even by accident — and it adds no test-only parameter to a production CLI option bag. The leaf
+  keeps `homeOverride` for its own unit tests, which is where it earns its keep.

--- a/docs/reviews/2026-09-02-v1-review/tracks/specs/F-doctor-1811.md
+++ b/docs/reviews/2026-09-02-v1-review/tracks/specs/F-doctor-1811.md
@@ -24,16 +24,30 @@ never mentions it. That is the fix here, and it is the shape the track file reco
 
 ## Fix
 
-- **New shared leaf `src/shared/integrations/tandem-plugin.ts`** (~35 lines), sibling of the
-  existing `client-config-paths.ts` — whose own doctrine comment ("Path from the shared leaf, so
-  doctor inspects the file `detectTargets` writes rather than a second hand-maintained copy of the
-  same rule") is the precedent for putting the predicate in one place instead of duplicating it:
+- **New shared leaf `src/shared/integrations/tandem-plugin.ts`** (~35 lines), placed as a sibling
+  of the existing `client-config-paths.ts`. **It is not an application of that file's
+  "one hand-maintained copy of the path rule" doctrine, and must not cite it** — the leaf derives
+  `<home>/.claude/settings.json` itself, and `checkTandemPlugin` keeps deriving the same path
+  independently (`src/cli/doctor.ts:1996`), with a third literal in
+  `tests/cli/doctor-path-safety.test.ts:127,261`. What this leaf de-duplicates is the **predicate**,
+  not the path; claiming the path doctrine would assert a consolidation the spec is not
+  performing. (Adding `claudeCodeSettingsPath()` to `client-config-paths.ts` and repointing both
+  callers is the real fix for the path copies — deliberately out of scope here, see Not in scope.)
   - `findEnabledTandemPluginKey(enabledPlugins: Record<string, unknown> | null | undefined): string | null`
     — pure; the predicate lifted verbatim from `evaluateTandemPlugin`:
     `key.startsWith("tandem@") && value === true`. **Test the value, not truthiness** — `false` is
     a deliberately disabled plugin — and match any marketplace suffix, because
     `docs/spikes/plugin-delivery.md` recommends a local one and a hardcoded
     `tandem@tandem-editor` in a remedy hands those users a command that errors.
+
+    **The key is also shape-clamped: return it only when it matches
+    `/^tandem@[A-Za-z0-9._-]+$/`, otherwise `null`.** The key is arbitrary JSON-key text read out
+    of `~/.claude/settings.json` and this spec interpolates it into a copy-paste-ready
+    `claude plugin uninstall <key>` printed to the operator's terminal, so a key carrying a newline
+    or an ANSI escape would render as something other than what it is. Doctor already interpolates
+    unclamped (`src/cli/doctor.ts:1944`) — so this narrows a pre-existing surface rather than
+    adding a class, and the clamp satisfies the any-marketplace-suffix requirement above by
+    construction.
   - `detectEnabledTandemPlugin(opts: { homeOverride?: string } = {}): string | null`.
 
     **Home resolution is pinned, because the production call site passes no argument and the
@@ -44,18 +58,27 @@ never mentions it. That is the fix here, and it is the shape the track file reco
     if (!home) return null;
     ```
 
-    **`||` and the explicit empty-home return, not `??`** — the two cited sites are
-    `const home = process.env.HOME || process.env.USERPROFILE || "";` followed by `if (!home)
-    return;` (`checkTandemPlugin`, `src/cli/doctor.ts:1972-1973`; `checkUserMcpConfig` at `:1106`
-    passes `home || undefined` so `claudeCodeConfigPath` falls back to `homedir()`). `""` is not
-    nullish, so under `??` an empty `HOME` *wins* the chain, and the UNC screen below cannot catch
-    it: `homeIsUnsafe` is `home !== "" && rejectUnsafeWindowsPrefix(home) !== null`
-    (`src/cli/doctor.ts:681-683`), false for `""` **by construction** — which is exactly why
-    doctor pairs it with `if (!home) return`. The consequence is not abstract:
-    `join("", ".claude", "settings.json")` is **cwd-relative**, so `tandem setup --apply` run
-    inside any checkout would read *that repo's* `.claude/settings.json` — a file that exists in
-    this repo — and interpolate one of its JSON keys into the
-    `claude plugin uninstall <key>` command printed to the operator.
+    **`if (!home) return null;` is the control here — not the choice of `||` over `??`.** Keep
+    the two separate, because conflating them produced a spec that could not be written:
+
+    - **The guard is what closes the cwd-relative read.** `join("", ".claude", "settings.json")`
+      is **cwd-relative**, so a leaf without that line, run inside any checkout, would read *that
+      repo's* `.claude/settings.json` — a file that exists in this repo — and interpolate one of
+      its JSON keys into the `claude plugin uninstall <key>` command printed to the operator. The
+      UNC screen cannot cover it: `homeIsUnsafe` is
+      `home !== "" && rejectUnsafeWindowsPrefix(home) !== null` (`src/cli/doctor.ts:681-683`),
+      false for `""` **by construction** — which is exactly why doctor pairs it with
+      `if (!home) return`. This is true under `||` and under `??` alike; the guard, not the
+      operator, is the security control.
+    - **`||` is chosen for parity, not for safety.** Both cited sites spell it that way:
+      `const home = process.env.HOME || process.env.USERPROFILE || "";` followed by `if (!home)
+      return;` (`checkTandemPlugin`, `src/cli/doctor.ts:1972-1973`; `checkUserMcpConfig` at
+      `:1106` passes `home || undefined` so `claudeCodeConfigPath` falls back to `homedir()`).
+      What the operator actually decides is the *empty-string* case: `""` is not nullish, so under
+      `??` an empty `HOME` stops the chain and the guard returns `null`, while under `||` the chain
+      falls through to `USERPROFILE` and then `homedir()` and the leaf still answers. A machine
+      exporting `HOME=""` is one where `homedir()` has the right answer, so `??` would make the
+      leaf silently decline to look. That is a behaviour difference, not a hole.
 
     `apply.ts`'s siblings (`:754`, `:2066`, `:2127`) use `opts.homeOverride ?? homedir()`, and
     `homedir()` reads `USERPROFILE` on Windows and ignores `HOME` — so a test that stubs `HOME`
@@ -140,23 +163,46 @@ still made) is tested with the module mocked, so no real filesystem read happens
   - `findEnabledTandemPluginKey` returns the key for `{"tandem@tandem-editor": true}`; `null` for
     `{"tandem@x": false}` (kills a truthiness check); `null` for `{"other@y": true}`; `null` for
     `null`/`undefined`/`{}`; returns the key for a non-default marketplace
-    `{"tandem@local-marketplace": true}` (kills a hardcoded suffix).
+    `{"tandem@local-marketplace": true}` (kills a hardcoded suffix); **`null` for a key whose
+    suffix carries a newline or an ANSI escape** (`"tandem@x\ny"`, `"tandem@[31mx"`) — the
+    shape clamp, which is what keeps an arbitrary settings-file key out of a copy-paste-ready
+    shell command.
   - `detectEnabledTandemPlugin({ homeOverride })` against a temp home: absent file → `null`;
     malformed JSON → `null` (no throw); `enabledPlugins` present → the key.
   - **Home resolution**, with no `homeOverride`: stub `HOME` to a temp dir carrying the settings
     file → the key; then unstub `HOME`, stub `USERPROFILE` to it → the key. Both stubs, because
     only one of them survives on each platform. `vi.unstubAllEnvs()` in `afterEach`.
-  - **Empty home** — the `||`-vs-`??` guard. With **no** `homeOverride` and both `HOME` and
-    `USERPROFILE` stubbed to `""`, `detectEnabledTandemPlugin()` returns `null` and the
-    `readFileSync` mock is `not.toHaveBeenCalled()`. Under `??` this reds: `""` wins the chain,
-    `homeIsUnsafe("")` is false by its own `home !== ""` clause, and the leaf reads a cwd-relative
-    `.claude/settings.json`. (`homedir()` must be mocked or the stubs must survive it — assert the
-    syscall, which is true either way.)
-  - **Derived-path screen** — the second UNC screen. `detectEnabledTandemPlugin({ homeOverride:
-    "\\" })` (a single backslash, the measured POSIX case at `src/cli/doctor.ts:654-684`): it
-    passes the raw screen and derives an unsafe path, so `readFileSync` must still be
-    `not.toHaveBeenCalled()`. This is the only spec that reds if the derived-path screen is
-    dropped in favour of the non-existent "backstop".
+  - **`homedir()` must be mocked in this file, not merely out-stubbed.** Mock `node:os`'s
+    `homedir` with the same `vi.hoisted` + `vi.mock` technique mandated for `node:fs` below.
+    `homedir()` reads `USERPROFILE` on Windows and **ignores an empty one**, so any spec that
+    empties the env vars falls through to the operator's real profile and issues a real read of
+    `~/.claude/settings.json` — breaking this group's standing rule with the spec that exists to
+    enforce it.
+  - **`||`-chain fall-through** — the spec that discriminates the operator. Mock `homedir()` to a
+    scratch temp dir carrying the settings file, stub **both** `HOME` and `USERPROFILE` to `""`,
+    call `detectEnabledTandemPlugin()` with no options, and assert the **positive**: `readFileSync`
+    was called with `join(scratchHome, ".claude", "settings.json")`, and never with a cwd-relative
+    `.claude/settings.json`. This is what reds under `??`, which stops the chain at `""` and
+    returns before making any call at all.
+  - **Empty home** — pins the `if (!home) return null;` guard, **not** the `||`/`??` spelling.
+    Mock `homedir()` to `""`, stub `HOME` and `USERPROFILE` to `""`, call with no options: returns
+    `null` and the `readFileSync` mock is `not.toHaveBeenCalled()`. Deleting the guard line reds
+    it, because `join("", ".claude", "settings.json")` is cwd-relative and `homeIsUnsafe`'s
+    `home !== ""` clause cannot screen it. Both operators pass this one — that is the point of
+    splitting it from the spec above.
+  - **Derived-path screen** — the second UNC screen, and **it is POSIX-only: gate it
+    `it.runIf(process.platform !== "win32")`.** `detectEnabledTandemPlugin({ homeOverride: "\\" })`
+    (a single backslash, the measured POSIX case at `src/cli/doctor.ts:654-684`) passes the raw
+    screen; on posix `path.posix.join` derives `\/.claude/settings.json`, whose normalised head is
+    `\\` and which `rejectUnsafeWindowsPrefix` rejects, so `readFileSync` must be
+    `not.toHaveBeenCalled()`. On win32 `path.win32.join` yields `\.claude\settings.json` — a
+    **single** leading separator, which `src/shared/windows-path-safety.ts:62-84` accepts — so
+    ungated the spec reds against correct code on the machine this wave runs on. Copy the
+    precedent's one-line reason: `tests/cli/doctor-path-safety.test.ts:643-664` gates the identical
+    lone-backslash input the same way, noting that its evidence is CI's ubuntu job, not a local
+    green. Gated, this is still the only spec that reds if the derived-path screen is dropped in
+    favour of the non-existent "backstop"; leave the two `NETWORK_PATHS` tables below **ungated** —
+    the raw screen catches every row on both platforms.
   - **UNC table, twice — once per input path, because production takes the one the round-1 spec
     did not drive.** `applySetup` calls `detectEnabledTandemPlugin()` with **no argument**, so its
     real input is `process.env.HOME || USERPROFILE || homedir()`. A screen written as
@@ -180,6 +226,25 @@ still made) is tested with the module mocked, so no real filesystem read happens
     configurable, so `vi.spyOn` **throws**. The technique and this exact rationale are documented
     at `tests/cli/doctor-path-safety.test.ts:22-25` (same as
     `tests/server/unc-guard-ordering.test.ts`); copy it.
+
+    **But do not copy that file's `readFileSync` mock body, which delegates straight to the real
+    implementation** (`_readFileSyncSpy.mockImplementation(actual.readFileSync as never)`,
+    `tests/cli/doctor-path-safety.test.ts:52-56`). A red/TDD run of the eleven `NETWORK_PATHS`
+    rows above would then perform, on Windows, the SMB handshake #1417 exists to prevent — the
+    incident that same file records at `:64-77` ("this suite issued a REAL `statSync` against a
+    `\attacker\share\...` path … the Responder NTLM-relay vector … fired from a developer's
+    machine on every pre-push run"). **The leaf suite's mock refuses hostile prefixes itself**,
+    mirroring the containment stub at `:64-83`:
+
+    ```
+    if (typeof p === "string" && rejectUnsafeWindowsPrefix(p) !== null) {
+      throw Object.assign(new Error("ENOENT (test stub: refused before syscall)"), { code: "ENOENT" });
+    }
+    ```
+
+    before delegating to `actual.readFileSync`. It asserts nothing — the specs assert on the spy's
+    call record, which the throw does not disturb — so it cannot mask a genuine failure, and a
+    failing run cannot make the syscall the spec exists to forbid.
 - `tests/cli/run-setup-apply.test.ts` — **this file, not `setup.test.ts`.** Add
   `vi.mock("../../src/shared/integrations/tandem-plugin.js", …)` alongside the existing
   `apply.js` mock (`:13-30`), stubbing `detectEnabledTandemPlugin`. That file mocks only
@@ -209,17 +274,36 @@ still made) is tested with the module mocked, so no real filesystem read happens
 ## Done when
 
 `setup --apply` on a machine with the plugin installed says so and names the remedy before it
-writes; the predicate exists once; the leaf refuses every `NETWORK_PATHS` spelling before any
+writes; the leaf refuses every `NETWORK_PATHS` spelling before any
 syscall **through both input paths — `homeOverride` and the env chain production actually
 takes**; an empty `HOME` returns `null` rather than reading a cwd-relative `.claude/settings.json`;
-no test reads a real home; doctor's existing duplication warn is pinned; typecheck + the CLI and
-shared suites green. The PR body records the refutation with the `git show` citation.
+no test reads a real home; the key clamp rejects a newline/ANSI suffix; doctor's existing
+duplication warn is pinned; typecheck + the CLI and shared suites green. The PR body records the
+refutation with the `git show` citation.
+
+**"The predicate exists once" is deliberately NOT a done-when.** No listed spec would red if the
+implementation added the leaf and left `evaluateTandemPlugin`'s inline
+`Object.entries(...).find(...)` in place: the duplication-warn pin at the end of Tests asserts
+behaviour that is identical either way. Making it checkable means a source-read assertion in the
+shape of `tests/cli/doctor-path-safety.test.ts:694-717` (`src/cli/doctor.ts` contains no
+`startsWith("tandem@")` outside the shared leaf), and this wave's minimal-fix bar does not buy new
+scanning machinery for a one-line substitution. The substitution stays in the Fix as a
+review-verified change; claiming it as a done-when nothing checks is the #1529 shape.
 
 ## Not in scope
 
 A doctor `--fix` flag (a new CLI surface; not in the taken shape). README / wizard copy (docs
 drift is #1821 / the J2 group). Making `setup --apply` skip the MCP write. Anything about the
 plugin's own npx pin — that is #1790.
+
+**Consolidating the `<home>/.claude/settings.json` path derivation.** Three copies exist after
+this change (the leaf, `src/cli/doctor.ts:1996`, and the `SETTINGS_LEAF` literal at
+`tests/cli/doctor-path-safety.test.ts:127,261`). The right fix is
+`claudeCodeSettingsPath(opts: ClientConfigPathOptions)` in
+`src/shared/integrations/client-config-paths.ts` with both callers repointed — a refactor of a
+UNC-screened doctor path, which exceeds this group's minimal-fix bar and would land untested
+inside a `setup --apply` PR. This spec de-duplicates the **predicate** only and says so in the Fix
+rather than borrowing that file's doctrine.
 
 ## Files touched
 
@@ -297,6 +381,52 @@ plugin's own npx pin — that is #1790.
 - *The spec prescribes `vi.spyOn(fs, "readFileSync")`, which this repo has measured as broken on
   an ESM builtin namespace.* Reworded to `vi.hoisted` + `vi.mock("node:fs", …)`, citing the
   documented rationale at `tests/cli/doctor-path-safety.test.ts:22-25`.
+
+**Not adopted**
+
+- None.
+
+## Review corrections (round 3)
+
+**Adopted**
+
+- **BLOCKING** *The "Empty home" spec was self-contradictory and non-discriminating: under the
+  `||` chain the same spec mandates, `""` does not win — `homedir()` does, the guard never fires,
+  and `readFileSync` IS called on the operator's real `~/.claude/settings.json`; mocking
+  `homedir()` to `""` instead makes both spellings pass identically* (raised twice). It is now two
+  specs. A `||`-chain fall-through spec mocks `homedir()` to a scratch temp dir, empties both env
+  vars and asserts the **positive** call on `join(scratchHome, ".claude", "settings.json")` — which
+  reds under `??`, since `??` stops at `""` and returns before any call. A separate empty-home spec
+  mocks `homedir()` to `""` and pins `if (!home) return null;` alone. A new bullet requires
+  `homedir()` to be mocked in this file at all, because it ignores an empty `USERPROFILE` and would
+  otherwise route every emptied-env spec at the operator's real profile. The Fix's rationale is
+  rewritten: the guard, not the operator, is the security control; `||` is chosen for parity with
+  `src/cli/doctor.ts:1972-1973`, and the empty-string case is a behaviour difference, not a hole.
+- **BLOCKING** *The derived-path UNC spec is POSIX-only and was ungated, so it reds against correct
+  code on this wave's Windows machine — and the likely "repair" deletes the only spec pinning that
+  screen* (raised twice). It is now `it.runIf(process.platform !== "win32")`, with the measurement
+  in the spec (`path.win32.join("\\", ".claude", "settings.json")` → `\.claude\settings.json`, a
+  single separator that `src/shared/windows-path-safety.ts:62-84` accepts) and the precedent's
+  one-line reason copied from `tests/cli/doctor-path-safety.test.ts:643-664` — its evidence is CI's
+  ubuntu job, not a local green. The two `NETWORK_PATHS` tables stay ungated.
+- **BLOCKING** *The prescribed `node:fs` mock delegates to the real `readFileSync`, so a red/TDD
+  run of the eleven UNC rows performs the SMB handshake #1417 exists to prevent.* The Tests section
+  now requires the leaf suite's mock to refuse hostile prefixes itself before delegating, with the
+  `rejectUnsafeWindowsPrefix` throw spelled out, mirroring the containment stub at
+  `tests/cli/doctor-path-safety.test.ts:64-83` and citing the incident recorded at `:64-77`.
+- *The leaf cites `client-config-paths.ts`'s "not a second hand-maintained copy" doctrine while
+  hand-rolling `<home>/.claude/settings.json`, leaving that rule in three copies.* The citation is
+  removed: the Fix now states the leaf de-duplicates the **predicate**, not the path, names all
+  three path copies, and Not-in-scope records `claudeCodeSettingsPath()` as the real fix with why it
+  is out of bounds for this group.
+- *An untrusted `enabledPlugins` key is interpolated into a shell command printed to the terminal
+  with no shape clamp.* `findEnabledTandemPluginKey` now returns the key only when it also matches
+  `/^tandem@[A-Za-z0-9._-]+$/`, with a leaf spec for newline/ANSI suffixes and a note that this
+  narrows the pre-existing surface at `src/cli/doctor.ts:1944` rather than adding a class.
+- *Done-when claims "the predicate exists once", and no listed spec would red if doctor kept its
+  inline copy.* The claim is dropped, with a paragraph saying what would make it checkable (a
+  source-read assertion in the shape of `doctor-path-safety.test.ts:694-717`) and why this wave's
+  minimal-fix bar does not buy it — leaving an unchecked done-when is the #1529 shape.
 
 **Not adopted**
 

--- a/docs/reviews/2026-09-02-v1-review/tracks/specs/F-doctor-1811.md
+++ b/docs/reviews/2026-09-02-v1-review/tracks/specs/F-doctor-1811.md
@@ -32,11 +32,15 @@ scope cut).
     with the predicate verbatim: `key.startsWith("tandem@") && value === true`. **Test the value,
     not truthiness** (`false` is a deliberately disabled plugin) and match any marketplace suffix
     (`docs/spikes/plugin-delivery.md` recommends a local one, so a hardcoded `tandem@tandem-editor`
-    hands those users a command that errors). `evaluateTandemPlugin` calls it; behaviour unchanged.
-    **Return the key only when it also matches `/^tandem@[A-Za-z0-9._-]+$/`** — it is arbitrary
-    JSON-key text that this fix newly prints into `setup`'s terminal output inside a copy-paste
-    `claude plugin uninstall <key>`, and a newline or ANSI escape in it would render as something
-    other than what it is.
+    hands those users a command that errors). It returns the **raw key**, unclamped;
+    `evaluateTandemPlugin` calls it and its behaviour is genuinely unchanged.
+
+    **The key-shape clamp does NOT live in the finder.** `evaluateTandemPlugin` short-circuits
+    *both* of its outcomes on `undefined` (`if (installedKey === undefined) return [];`, `:1931`),
+    so a clamp inside the shared finder turns today's `pass` (`:1943-1961`) **and** the duplication
+    `warn` (`:1965-1972`) into silence for any marketplace suffix outside the character class —
+    doctor would stop reporting a plugin that is genuinely installed, which is a regression, not a
+    hardening. The clamp belongs to the one surface this fix newly adds, below.
   - Exported `detectEnabledTandemPluginKey(): string | null`, five lines beside
     `checkTandemPlugin`, reusing what that check already uses:
     `const home = process.env.HOME || process.env.USERPROFILE || "";` (the same spelling as
@@ -46,13 +50,21 @@ scope cut).
     `findEnabledTandemPluginKey(value.enabledPlugins ?? {})`. Absence is never evidence, and this
     must never make `setup --apply` fail.
 
+    **This is where the key shape is clamped:** return the key only when it also matches
+    `/^tandem@[A-Za-z0-9._-]+$/`, otherwise `null`. It is arbitrary JSON-key text that this fix
+    newly prints into `setup`'s terminal output inside a copy-paste
+    `claude plugin uninstall <key>`, and a newline or ANSI escape in it would render as something
+    other than what it is. Suppressing the *new* notice for such a key costs nothing; suppressing
+    doctor's existing report of an installed plugin would not. If the clamp is ever wanted on
+    doctor's `fix` string too, it must degrade to a warn without the copy-paste command — never to
+    silence.
+
     **`readClaudeConfig` is the point.** It is doctor's screened reader (`:595-607`) — the same one
     `checkTandemPlugin` uses, refusing an unsafe path (#1417) before any syscall and surfacing no
     parse detail. Using it means this adds no new reader, no second UNC screen and no new home
     chain: the two guards here are the two calls `checkTandemPlugin` already makes, and
     `tests/cli/doctor-path-safety.test.ts` already covers them.
-- **`src/cli/setup.ts`, `applySetup`:** immediately before
-  `console.error("Detecting Claude installations...")` (`:116`), `const pluginKey = (await
+- **`src/cli/setup.ts`, `applySetup`:** `const pluginKey = (await
   import("./doctor.js")).detectEnabledTandemPluginKey();` — dynamic, mirroring
   `src/cli/index.ts:178`, so `tandem setup` does not pay for loading doctor's dependency graph on
   every other path. When it returns a key, print one notice to stderr (setup's whole output is
@@ -60,6 +72,16 @@ scope cut).
 
   > The Tandem plugin (`<key>`) is installed and already provides the tandem_* tools. Writing this
   > config too makes every tool appear twice — keep one: `claude plugin uninstall <key>`
+
+  **Placement: after the `opts.targets` filter (`:121`), gated on
+  `targets.some((t) => t.kind === "claude-code")`, still before `writeTargets`.** The plugin is a
+  Claude Code plugin, so `tandem setup --apply --target=claude-desktop` writes no Claude Code
+  entry and duplicates nothing — printing "every tool appears twice" there is a false statement
+  prescribing the uninstall of a working plugin, the dead-end/false-remedy class this area has
+  already been corrected for twice (`src/cli/doctor.ts:1163-1190`, `:1345-1360`). Doctor gates its
+  own duplication warn on `wizardTandemEntry` for exactly this reason (`:1963-1972`: "a
+  plugin-only user has nothing duplicated and needs no warning"); the target filter is setup's
+  equivalent, and it is why the notice cannot sit above `detectTargets` at `:116`.
 
 - **The write still happens.** `--apply` is the scriptable, non-interactive path whose contract is
   "write the config"; silently skipping it would strand a user who later disables the plugin, with
@@ -78,16 +100,25 @@ skill edit.
   platform sets), with `vi.unstubAllEnvs()` + `rmSync` in `afterEach`. **This is required, not
   optional:** that file mocks only `apply.js`, so without it the new call reads the operator's real
   `~/.claude/settings.json` in all four existing `--apply` specs and the negative spec passes or
-  fails by machine — the #1894 hazard this group is told to avoid. Two specs:
+  fails by machine — the #1894 hazard this group is told to avoid. Three specs:
   - `<dir>/.claude/settings.json` = `{"enabledPlugins":{"tandem@tandem-editor":true}}` → stderr
     contains `plugin uninstall` **and `applyConfig` was still called** — the second assertion is
     the discriminating one, killing a fix that "helpfully" skips the write.
   - no settings file → no notice (kills a check that fires for every user).
+  - **Target-gated**: the same settings file, plus `detectTargets` yielding only the Claude
+    Desktop target (or `opts.targets: ["claude-desktop"]` filtering the Claude Code one out) →
+    **no notice**, and `applyConfig` still called. Kills the notice placed above `detectTargets`,
+    which would assert a duplication that a desktop-only run does not create.
 - `tests/cli/doctor.test.ts`:
   - `findEnabledTandemPluginKey`: the key for `{"tandem@tandem-editor": true}`; `null` for
     `{"tandem@x": false}` (kills a truthiness check), `{"other@y": true}`, `null` and `{}`; the key
-    for `{"tandem@local-marketplace": true}` (kills a hardcoded suffix); `null` for a suffix
-    carrying a newline or an ANSI escape (`"tandem@x\ny"`, `"tandem@[31mx"`).
+    for `{"tandem@local-marketplace": true}` (kills a hardcoded suffix); and — the clamp's
+    negative pin — the key **is still returned** for a suffix carrying a newline or an ANSI
+    escape, because the finder is unclamped and doctor must keep reporting the plugin.
+  - `detectEnabledTandemPluginKey` (scratch home, both env vars stubbed): the key for
+    `{"tandem@tandem-editor": true}`, and `null` for those same newline/ANSI suffixes written
+    into `<dir>/.claude/settings.json`. **This is the only place the clamp is asserted**, and it
+    kills both a missing clamp and a clamp pushed down into the shared finder.
   - Keep/add a pin that `evaluateTandemPlugin({ enabledPlugins: {"tandem@tandem-editor": true},
     wizardTandemEntry: true })` still yields the duplication warn whose `fix` names
     `claude plugin uninstall tandem@tandem-editor` — the refuted half is working behaviour with no
@@ -96,9 +127,10 @@ skill edit.
 ## Done when
 
 `setup --apply` on a machine with the plugin installed says so and names the remedy before it
-writes, and still writes; no test reads a real home; the key clamp rejects a newline/ANSI suffix;
-doctor's existing duplication warn is pinned; typecheck + the CLI suite green. The PR body records
-the refutation with the `git show` citation.
+writes, and still writes; a desktop-only `--apply` stays silent; no test reads a real home;
+`detectEnabledTandemPluginKey` rejects a newline/ANSI suffix while `findEnabledTandemPluginKey`
+still returns it; doctor's existing duplication warn is pinned; typecheck + the CLI suite green.
+The PR body records the refutation with the `git show` citation.
 
 ## Not in scope
 
@@ -140,3 +172,19 @@ repointed — a refactor of a UNC-screened doctor path, above this group's bar.
 The refutation of the issue's first half; the `setup --apply` notice with the write preserved; the
 value-not-truthiness predicate and any-marketplace matching; the key shape clamp (this fix is what
 newly prints that key to a terminal); the doctor duplication-warn pin.
+
+## Review corrections (post-cut)
+
+- **The key-shape clamp moved out of the shared finder into `detectEnabledTandemPluginKey`.**
+  Placing it in `findEnabledTandemPluginKey` would have deleted doctor's *existing* behaviour, not
+  hardened it: `evaluateTandemPlugin` returns `[]` on an `undefined` key
+  (`src/cli/doctor.ts:1931`), so a rejected marketplace suffix silenced both the installed-plugin
+  `pass` and the duplication `warn` — while the spec claimed "behaviour unchanged" and its only
+  `evaluateTandemPlugin` pin used `tandem@tandem-editor`, which passes the clamp. The doctor.test
+  specs are restated to match: the finder still returns a newline/ANSI key, the detector is what
+  rejects it.
+- **The `setup --apply` notice moved after the target filter** (`src/cli/setup.ts:121`) and is
+  gated on a `claude-code` target. Above `detectTargets` it printed "every tool appears twice" on
+  `--target=claude-desktop`, a run that writes no Claude Code entry and duplicates nothing — a
+  false statement prescribing the uninstall of a working plugin. A third `run-setup-apply` spec
+  pins the desktop-only silence.

--- a/docs/reviews/2026-09-02-v1-review/tracks/specs/F-doctor-1811.md
+++ b/docs/reviews/2026-09-02-v1-review/tracks/specs/F-doctor-1811.md
@@ -1,20 +1,19 @@
 # F-doctor — #1811 plugin + `tandem setup --apply` loads the `tandem_*` toolset twice
 
 Branch `fix/doctor-and-skill-version-skew-1806`. Closes #1811. Ledger:
-`docs/reviews/2026-09-02-v1-review/areas/skill-plugin.md:26`. No experiment (`[read]` row).
-Overlaps #1790 item 4 — the same condition, filed twice.
+`docs/reviews/2026-09-02-v1-review/areas/skill-plugin.md:26`. Overlaps #1790 item 4 — same
+condition, filed twice.
 
 ## Problem
 
-**One of the issue's two halves is refuted by the source, and the spec says so rather than
+**One of the issue's two halves is refuted by the source, and this spec says so rather than
 re-fixing it.** The cited `doctor.ts:1842-1845` at the review baseline `3fb6408` are the *doc
-comment* on `checkTandemPlugin` ("2. The plugin's MCP servers duplicate the ones setup writes"),
-not an emitter. The emitter is `evaluateTandemPlugin`'s second outcome, present unchanged at
-`3fb6408`: `status: "warn"`, message *"Both the Tandem plugin and a tandem MCP entry in
-~/.claude.json are present — the tandem_* tools will appear twice"*, `fix` naming the remedy
-`claude plugin uninstall ${installedKey}` with the key it actually found. So **doctor already
-detects the condition and already names the remedy.** Verified by `git show
-3fb6408:src/cli/doctor.ts | sed -n '1899,1912p'`.
+comment* on `checkTandemPlugin`, not an emitter. The emitter is `evaluateTandemPlugin`'s second
+outcome, present unchanged at `3fb6408`: `status: "warn"`, message *"Both the Tandem plugin and a
+tandem MCP entry in ~/.claude.json are present — the tandem_* tools will appear twice"*, with a
+`fix` naming `claude plugin uninstall ${installedKey}` for the key it actually found. **Doctor
+already detects the condition and already names the remedy.** Verified by
+`git show 3fb6408:src/cli/doctor.ts | sed -n '1899,1912p'`.
 
 What is genuinely missing is the other half: **`tandem setup --apply` says nothing.** It detects
 targets, writes the `~/.claude.json` MCP entry and installs the skill without ever looking at
@@ -24,410 +23,120 @@ never mentions it. That is the fix here, and it is the shape the track file reco
 
 ## Fix
 
-- **New shared leaf `src/shared/integrations/tandem-plugin.ts`** (~35 lines), placed as a sibling
-  of the existing `client-config-paths.ts`. **It is not an application of that file's
-  "one hand-maintained copy of the path rule" doctrine, and must not cite it** — the leaf derives
-  `<home>/.claude/settings.json` itself, and `checkTandemPlugin` keeps deriving the same path
-  independently (`src/cli/doctor.ts:1996`), with a third literal in
-  `tests/cli/doctor-path-safety.test.ts:127,261`. What this leaf de-duplicates is the **predicate**,
-  not the path; claiming the path doctrine would assert a consolidation the spec is not
-  performing. (Adding `claudeCodeSettingsPath()` to `client-config-paths.ts` and repointing both
-  callers is the real fix for the path copies — deliberately out of scope here, see Not in scope.)
-  - `findEnabledTandemPluginKey(enabledPlugins: Record<string, unknown> | null | undefined): string | null`
-    — pure; the predicate lifted verbatim from `evaluateTandemPlugin`:
-    `key.startsWith("tandem@") && value === true`. **Test the value, not truthiness** — `false` is
-    a deliberately disabled plugin — and match any marketplace suffix, because
-    `docs/spikes/plugin-delivery.md` recommends a local one and a hardcoded
-    `tandem@tandem-editor` in a remedy hands those users a command that errors.
+Two files. **No new module** — the detection reuses doctor's existing screened reader (see the
+scope cut).
 
-    **The key is also shape-clamped: return it only when it matches
-    `/^tandem@[A-Za-z0-9._-]+$/`, otherwise `null`.** The key is arbitrary JSON-key text read out
-    of `~/.claude/settings.json` and this spec interpolates it into a copy-paste-ready
-    `claude plugin uninstall <key>` printed to the operator's terminal, so a key carrying a newline
-    or an ANSI escape would render as something other than what it is. Doctor already interpolates
-    unclamped (`src/cli/doctor.ts:1944`) — so this narrows a pre-existing surface rather than
-    adding a class, and the clamp satisfies the any-marketplace-suffix requirement above by
-    construction.
-  - `detectEnabledTandemPlugin(opts: { homeOverride?: string } = {}): string | null`.
+- **`src/cli/doctor.ts`:**
+  - Lift `evaluateTandemPlugin`'s inline finder into an exported pure
+    `findEnabledTandemPluginKey(enabledPlugins: Record<string, unknown> | null): string | null`,
+    with the predicate verbatim: `key.startsWith("tandem@") && value === true`. **Test the value,
+    not truthiness** (`false` is a deliberately disabled plugin) and match any marketplace suffix
+    (`docs/spikes/plugin-delivery.md` recommends a local one, so a hardcoded `tandem@tandem-editor`
+    hands those users a command that errors). `evaluateTandemPlugin` calls it; behaviour unchanged.
+    **Return the key only when it also matches `/^tandem@[A-Za-z0-9._-]+$/`** — it is arbitrary
+    JSON-key text that this fix newly prints into `setup`'s terminal output inside a copy-paste
+    `claude plugin uninstall <key>`, and a newline or ANSI escape in it would render as something
+    other than what it is.
+  - Exported `detectEnabledTandemPluginKey(): string | null`, five lines beside
+    `checkTandemPlugin`, reusing what that check already uses:
+    `const home = process.env.HOME || process.env.USERPROFILE || "";` (the same spelling as
+    `src/cli/doctor.ts:1971`, so there is no `homedir()` fallback and no cwd-relative read to
+    guard); `if (!home || homeIsUnsafe(home)) return null;`; `readClaudeConfig(join(home,
+    ".claude", "settings.json"))`; anything but `kind === "ok"` → `null`; otherwise
+    `findEnabledTandemPluginKey(value.enabledPlugins ?? {})`. Absence is never evidence, and this
+    must never make `setup --apply` fail.
 
-    **Home resolution is pinned, because the production call site passes no argument and the
-    two spellings in this repo do not agree.** Use
+    **`readClaudeConfig` is the point.** It is doctor's screened reader (`:595-607`) — the same one
+    `checkTandemPlugin` uses, refusing an unsafe path (#1417) before any syscall and surfacing no
+    parse detail. Using it means this adds no new reader, no second UNC screen and no new home
+    chain: the two guards here are the two calls `checkTandemPlugin` already makes, and
+    `tests/cli/doctor-path-safety.test.ts` already covers them.
+- **`src/cli/setup.ts`, `applySetup`:** immediately before
+  `console.error("Detecting Claude installations...")` (`:116`), `const pluginKey = (await
+  import("./doctor.js")).detectEnabledTandemPluginKey();` — dynamic, mirroring
+  `src/cli/index.ts:178`, so `tandem setup` does not pay for loading doctor's dependency graph on
+  every other path. When it returns a key, print one notice to stderr (setup's whole output is
+  stderr):
 
-    ```
-    const home = opts.homeOverride || process.env.HOME || process.env.USERPROFILE || homedir();
-    if (!home) return null;
-    ```
+  > The Tandem plugin (`<key>`) is installed and already provides the tandem_* tools. Writing this
+  > config too makes every tool appear twice — keep one: `claude plugin uninstall <key>`
 
-    **`if (!home) return null;` is the control here — not the choice of `||` over `??`.** Keep
-    the two separate, because conflating them produced a spec that could not be written:
-
-    - **The guard is what closes the cwd-relative read.** `join("", ".claude", "settings.json")`
-      is **cwd-relative**, so a leaf without that line, run inside any checkout, would read *that
-      repo's* `.claude/settings.json` — a file that exists in this repo — and interpolate one of
-      its JSON keys into the `claude plugin uninstall <key>` command printed to the operator. The
-      UNC screen cannot cover it: `homeIsUnsafe` is
-      `home !== "" && rejectUnsafeWindowsPrefix(home) !== null` (`src/cli/doctor.ts:681-683`),
-      false for `""` **by construction** — which is exactly why doctor pairs it with
-      `if (!home) return`. This is true under `||` and under `??` alike; the guard, not the
-      operator, is the security control.
-    - **`||` is chosen for parity, not for safety.** Both cited sites spell it that way:
-      `const home = process.env.HOME || process.env.USERPROFILE || "";` followed by `if (!home)
-      return;` (`checkTandemPlugin`, `src/cli/doctor.ts:1972-1973`; `checkUserMcpConfig` at
-      `:1106` passes `home || undefined` so `claudeCodeConfigPath` falls back to `homedir()`).
-      What the operator actually decides is the *empty-string* case: `""` is not nullish, so under
-      `??` an empty `HOME` stops the chain and the guard returns `null`, while under `||` the chain
-      falls through to `USERPROFILE` and then `homedir()` and the leaf still answers. A machine
-      exporting `HOME=""` is one where `homedir()` has the right answer, so `??` would make the
-      leaf silently decline to look. That is a behaviour difference, not a hole.
-
-    `apply.ts`'s siblings (`:754`, `:2066`, `:2127`) use `opts.homeOverride ?? homedir()`, and
-    `homedir()` reads `USERPROFILE` on Windows and ignores `HOME` — so a test that stubs `HOME`
-    alone would silently read the operator's real profile on the platform this wave runs on.
-    Writing the env reads explicitly is what makes both stubs work.
-
-    **Two UNC screens, not one — the derived path alone is not enough, and neither is the raw
-    value alone.** Screen the raw `home` value **before** any `join`, in `homeIsUnsafe`'s shape
-    (`home !== "" && rejectUnsafeWindowsPrefix(home) !== null` — `rejectUnsafeWindowsPrefix` from
-    `src/shared/windows-path-safety.ts`); then, after resolving
-    `<home>/.claude/settings.json`, run **a second explicit screen in the leaf**:
-    `if (rejectUnsafeWindowsPrefix(settingsPath) !== null) return null;` immediately before the
-    `readFileSync`. The round-1 text said "let the read's own screen stand as a backstop" — the
-    leaf's reader **has** no screen (that backstop belongs to `readClaudeConfig`,
-    `src/cli/doctor.ts:607`, which the layering rules out below), so shipping that sentence would
-    assert a control that is not in the code: #1417's own drift class. The measured POSIX case it
-    is there for is at `src/cli/doctor.ts:654-684`: a `$HOME` of a single backslash passes the raw
-    screen and derives `\/.claude/settings.json`.
-
-    That same block records the measurement the **raw**-value screen comes from, which is the
-    half a derived-path-only guard misses: of the fourteen spellings in
-    `tests/helpers/unc-fixtures.ts`, four pure
-    forward-slash forms "collapse to a path this guard then accepts once `path.posix.join` has
-    run". A derived-path-only screen therefore passes those rows on ubuntu — the only platform
-    `check` runs — *because the path stopped being dangerous, not because anything screened it*:
-    the #1529 shape, a non-discriminating test that reads exactly like a pass. #1417 is the
-    underlying rule (reading a UNC path performs the SMB handshake that leaks an NTLM hash), so
-    the screen must precede the read, not wrap it.
-
-    Then `readFileSync` + `JSON.parse` inside a total `try/catch`, returning
-    `findEnabledTandemPluginKey(parsed.enabledPlugins)`. Every failure → `null`: absence is not
-    evidence, and this must never make `setup --apply` fail.
-
-    **On the unfenced-reader fence.** `tests/cli/doctor-path-safety.test.ts:694-717` keeps the
-    unfenced `readJson` away from Claude configs, and it reads `src/cli/doctor.ts` only
-    (`:695`), so a reader in `src/shared/integrations/` is invisible to it. The leak class it
-    guards is structurally absent here — this leaf's whole return type is `string | null`, it
-    carries no `reason` field and never surfaces parse detail, which is exactly why
-    `readClaudeConfig` exists separately (`src/cli/doctor.ts:595-604`). Reusing
-    `readClaudeConfig` is not available: it lives in `src/cli/`, and `src/shared/` importing
-    upward inverts the layering. So **extend the fence's scan set instead**: make its `SOURCE`
-    the concatenation of `src/cli/doctor.ts` and `src/shared/integrations/tandem-plugin.ts`, so a
-    future `readJson(join(home, ".claude", "settings.json"))` added to the leaf reds the fence
-    rather than shipping unseen.
-
-    **Label the extension in the fence's comment as forward-looking only, because it cannot fail
-    today and must not be read as coverage of the reader this spec adds.** The fence matches
-    `readJson(` call sites (`tests/cli/doctor-path-safety.test.ts:696-700`); `readJson` is
-    module-private to `doctor.ts` (`src/cli/doctor.ts:514`, no `export`) and the layering rule
-    above forbids importing it, so no such call site can exist in the leaf. The leaf reads with
-    `readFileSync` + `JSON.parse`, which that regex can never see, and the positive control at
-    `:704` stays satisfied by `doctor.ts`'s own sites either way. What actually pins the leaf's
-    reader is the explicit `rejectUnsafeWindowsPrefix(settingsPath)` screen above plus the UNC
-    table below — not this fence.
-- **`src/cli/doctor.ts`:** `evaluateTandemPlugin` calls `findEnabledTandemPluginKey(input.enabledPlugins)`
-  in place of its inline `Object.entries(...).find(...)`. One line, no behaviour change — it exists
-  so the two surfaces cannot drift. Doctor keeps its own reader, its own `homeIsUnsafe` screen and
-  its own reporting; it does **not** import `detectEnabledTandemPlugin`.
-- **`src/cli/setup.ts`, `applySetup`:** call `detectEnabledTandemPlugin()` once, immediately before
-  `console.error("Detecting Claude installations...")` (`src/cli/setup.ts:116`), and when it
-  returns a key print one notice to stderr (setup's whole output is stderr):
-  `The Tandem plugin (<key>) is installed and already provides the tandem_* tools. Writing this
-  config too makes every tool appear twice — keep one: claude plugin uninstall <key>`.
 - **The write still happens.** `--apply` is the scriptable, non-interactive path whose contract is
   "write the config"; silently skipping it would strand a user who later disables the plugin, with
   no output saying why nothing was written. Warn, do not skip. (Assumption; the issue's own
   suggestion offers skipping, the track file's taken shape says warn.)
 
-Rules that bite: **never against the real HOME** — see the Tests section, which pins *how* rather
-than only asserting the rule. No config *writer* is added (#1599's bound and
-`tests/docs/config-writer-set-claims.test.ts` count durable write sites; this is a read). No new
-`/api` route, no MCP tool, no skill edit.
+Rules that bite: no config *writer* is added — this is a read, so #1599's bound and
+`tests/docs/config-writer-set-claims.test.ts` are untouched. No new `/api` route, no MCP tool, no
+skill edit.
 
 ## Tests
 
-The two levels are tested through different seams, and the split is the point: the **leaf's own
-behaviour** (home resolution, UNC screen, JSON handling) is unit-tested with an explicit
-`homeOverride`; the **`applySetup` wiring** (is it called, is the notice printed, is the write
-still made) is tested with the module mocked, so no real filesystem read happens at all.
-
-- `tests/shared/integrations/tandem-plugin.test.ts` (new):
-  - `findEnabledTandemPluginKey` returns the key for `{"tandem@tandem-editor": true}`; `null` for
-    `{"tandem@x": false}` (kills a truthiness check); `null` for `{"other@y": true}`; `null` for
-    `null`/`undefined`/`{}`; returns the key for a non-default marketplace
-    `{"tandem@local-marketplace": true}` (kills a hardcoded suffix); **`null` for a key whose
-    suffix carries a newline or an ANSI escape** (`"tandem@x\ny"`, `"tandem@[31mx"`) — the
-    shape clamp, which is what keeps an arbitrary settings-file key out of a copy-paste-ready
-    shell command.
-  - `detectEnabledTandemPlugin({ homeOverride })` against a temp home: absent file → `null`;
-    malformed JSON → `null` (no throw); `enabledPlugins` present → the key.
-  - **Home resolution**, with no `homeOverride`: stub `HOME` to a temp dir carrying the settings
-    file → the key; then unstub `HOME`, stub `USERPROFILE` to it → the key. Both stubs, because
-    only one of them survives on each platform. `vi.unstubAllEnvs()` in `afterEach`.
-  - **`homedir()` must be mocked in this file, not merely out-stubbed.** Mock `node:os`'s
-    `homedir` with the same `vi.hoisted` + `vi.mock` technique mandated for `node:fs` below.
-    `homedir()` reads `USERPROFILE` on Windows and **ignores an empty one**, so any spec that
-    empties the env vars falls through to the operator's real profile and issues a real read of
-    `~/.claude/settings.json` — breaking this group's standing rule with the spec that exists to
-    enforce it.
-  - **`||`-chain fall-through** — the spec that discriminates the operator. Mock `homedir()` to a
-    scratch temp dir carrying the settings file, stub **both** `HOME` and `USERPROFILE` to `""`,
-    call `detectEnabledTandemPlugin()` with no options, and assert the **positive**: `readFileSync`
-    was called with `join(scratchHome, ".claude", "settings.json")`, and never with a cwd-relative
-    `.claude/settings.json`. This is what reds under `??`, which stops the chain at `""` and
-    returns before making any call at all.
-  - **Empty home** — pins the `if (!home) return null;` guard, **not** the `||`/`??` spelling.
-    Mock `homedir()` to `""`, stub `HOME` and `USERPROFILE` to `""`, call with no options: returns
-    `null` and the `readFileSync` mock is `not.toHaveBeenCalled()`. Deleting the guard line reds
-    it, because `join("", ".claude", "settings.json")` is cwd-relative and `homeIsUnsafe`'s
-    `home !== ""` clause cannot screen it. Both operators pass this one — that is the point of
-    splitting it from the spec above.
-  - **Derived-path screen** — the second UNC screen, and **it is POSIX-only: gate it
-    `it.runIf(process.platform !== "win32")`.** `detectEnabledTandemPlugin({ homeOverride: "\\" })`
-    (a single backslash, the measured POSIX case at `src/cli/doctor.ts:654-684`) passes the raw
-    screen; on posix `path.posix.join` derives `\/.claude/settings.json`, whose normalised head is
-    `\\` and which `rejectUnsafeWindowsPrefix` rejects, so `readFileSync` must be
-    `not.toHaveBeenCalled()`. On win32 `path.win32.join` yields `\.claude\settings.json` — a
-    **single** leading separator, which `src/shared/windows-path-safety.ts:62-84` accepts — so
-    ungated the spec reds against correct code on the machine this wave runs on. Copy the
-    precedent's one-line reason: `tests/cli/doctor-path-safety.test.ts:643-664` gates the identical
-    lone-backslash input the same way, noting that its evidence is CI's ubuntu job, not a local
-    green. Gated, this is still the only spec that reds if the derived-path screen is dropped in
-    favour of the non-existent "backstop"; leave the two `NETWORK_PATHS` tables below **ungated** —
-    the raw screen catches every row on both platforms.
-  - **UNC table, twice — once per input path, because production takes the one the round-1 spec
-    did not drive.** `applySetup` calls `detectEnabledTandemPlugin()` with **no argument**, so its
-    real input is `process.env.HOME || USERPROFILE || homedir()`. A screen written as
-    `if (opts.homeOverride && rejectUnsafeWindowsPrefix(opts.homeOverride))` passes an
-    override-only table on all eleven rows while leaving a redirected `%USERPROFILE%` on a share —
-    the exact #1417 scenario — completely unscreened. Precedent for treating the env path as a
-    distinct guard site: `tests/cli/doctor-path-safety.test.ts:812-826` drives
-    `process.env.HOME`/`USERPROFILE` with the corpus separately from the `homeOverride` block at
-    `:833-838`, and `:857-860` records that a mutation removing the input screen survived the
-    whole suite. So, both driven over `NETWORK_PATHS` from `tests/helpers/unc-fixtures.ts` rather
-    than a single `\\\\host\\share` case:
-    - `it.each([...NETWORK_PATHS])` → `detectEnabledTandemPlugin({ homeOverride: p })`.
-    - `it.each([...NETWORK_PATHS])` → set `process.env.HOME` **and** `process.env.USERPROFILE` to
-      the hostile spelling and call `detectEnabledTandemPlugin()` with **no options**.
-
-    For every row of both, **no filesystem call**. Per `unc-fixtures.ts`'s standing rule, assert
-    the `readFileSync` spy `not.toHaveBeenCalled()` — asserting the `null` return proves nothing,
-    because the unscreened code returns `null` too (the syscall throws).
-  - **Mock `node:fs` with `vi.hoisted` + `vi.mock("node:fs", …)`, never `vi.spyOn(fs, …)`.** The
-    leaf imports `readFileSync` from `node:fs` directly and an ESM module namespace is not
-    configurable, so `vi.spyOn` **throws**. The technique and this exact rationale are documented
-    at `tests/cli/doctor-path-safety.test.ts:22-25` (same as
-    `tests/server/unc-guard-ordering.test.ts`); copy it.
-
-    **But do not copy that file's `readFileSync` mock body, which delegates straight to the real
-    implementation** (`_readFileSyncSpy.mockImplementation(actual.readFileSync as never)`,
-    `tests/cli/doctor-path-safety.test.ts:52-56`). A red/TDD run of the eleven `NETWORK_PATHS`
-    rows above would then perform, on Windows, the SMB handshake #1417 exists to prevent — the
-    incident that same file records at `:64-77` ("this suite issued a REAL `statSync` against a
-    `\attacker\share\...` path … the Responder NTLM-relay vector … fired from a developer's
-    machine on every pre-push run"). **The leaf suite's mock refuses hostile prefixes itself**,
-    mirroring the containment stub at `:64-83`:
-
-    ```
-    if (typeof p === "string" && rejectUnsafeWindowsPrefix(p) !== null) {
-      throw Object.assign(new Error("ENOENT (test stub: refused before syscall)"), { code: "ENOENT" });
-    }
-    ```
-
-    before delegating to `actual.readFileSync`. It asserts nothing — the specs assert on the spy's
-    call record, which the throw does not disturb — so it cannot mask a genuine failure, and a
-    failing run cannot make the syscall the spec exists to forbid.
-- `tests/cli/run-setup-apply.test.ts` — **this file, not `setup.test.ts`.** Add
-  `vi.mock("../../src/shared/integrations/tandem-plugin.js", …)` alongside the existing
-  `apply.js` mock (`:13-30`), stubbing `detectEnabledTandemPlugin`. That file mocks only
-  `apply.js` today, so an unmocked call into a *different* module would `readFileSync` the real
-  `homedir()/.claude/settings.json` in all four of its existing `runSetup({ apply: true })` specs
-  — the #1894 hazard class this group is explicitly told to avoid, and it would make the negative
-  specs pass or fail by machine. Specs:
-  - stub returns `"tandem@tandem-editor"` → `--apply` prints a notice containing
-    `plugin uninstall` **and still calls `applyConfig`** — the second assertion is the
-    discriminating one, killing a fix that "helpfully" skips the write.
-  - stub returns `null` → no notice (kills a check that fires for every user).
-
-  There is deliberately **no** `applySetup` spec in `tests/cli/setup.test.ts`: nothing there
-  drives `runSetup({ apply: true })` today (`:1034`, `:1044` drive `runSetup()` and
-  `runSetup({ apply: false, force: true })`), and that file states at `run-setup-apply.test.ts:9-11`
-  that it exercises the **real** `apply.js` — so adding an `--apply` driver there would run the
-  real `detectTargets`/`applyConfig` against the real home. Do not put the notice specs there.
-- `tests/cli/doctor.test.ts`: keep/add a pin that `evaluateTandemPlugin({ enabledPlugins:
-  {"tandem@tandem-editor": true}, wizardTandemEntry: true })` still yields the duplication `warn`
-  whose `fix` names `claude plugin uninstall tandem@tandem-editor` — the refuted half is a working
-  behaviour with no test of its own, and the refactor above touches its key-finding line.
-- `tests/cli/doctor-path-safety.test.ts`: extend the unfenced-reader fence's `SOURCE` to include
-  the new leaf, per the Fix — **forward-looking only**, and the comment must say so. It cannot
-  fail for the reader this spec adds (`readJson` is private to `doctor.ts` and the leaf reads with
-  `readFileSync`), so it is not what pins the leaf; the two UNC screens and the tables above are.
+- `tests/cli/run-setup-apply.test.ts` — **the wiring, against a scratch home, with nothing
+  mocked.** Its `beforeEach` gains `mkdtempSync` plus `vi.stubEnv("HOME", dir)` and
+  `vi.stubEnv("USERPROFILE", dir)` (both — `detectEnabledTandemPluginKey` reads whichever the
+  platform sets), with `vi.unstubAllEnvs()` + `rmSync` in `afterEach`. **This is required, not
+  optional:** that file mocks only `apply.js`, so without it the new call reads the operator's real
+  `~/.claude/settings.json` in all four existing `--apply` specs and the negative spec passes or
+  fails by machine — the #1894 hazard this group is told to avoid. Two specs:
+  - `<dir>/.claude/settings.json` = `{"enabledPlugins":{"tandem@tandem-editor":true}}` → stderr
+    contains `plugin uninstall` **and `applyConfig` was still called** — the second assertion is
+    the discriminating one, killing a fix that "helpfully" skips the write.
+  - no settings file → no notice (kills a check that fires for every user).
+- `tests/cli/doctor.test.ts`:
+  - `findEnabledTandemPluginKey`: the key for `{"tandem@tandem-editor": true}`; `null` for
+    `{"tandem@x": false}` (kills a truthiness check), `{"other@y": true}`, `null` and `{}`; the key
+    for `{"tandem@local-marketplace": true}` (kills a hardcoded suffix); `null` for a suffix
+    carrying a newline or an ANSI escape (`"tandem@x\ny"`, `"tandem@[31mx"`).
+  - Keep/add a pin that `evaluateTandemPlugin({ enabledPlugins: {"tandem@tandem-editor": true},
+    wizardTandemEntry: true })` still yields the duplication warn whose `fix` names
+    `claude plugin uninstall tandem@tandem-editor` — the refuted half is working behaviour with no
+    test of its own, and the substitution above touches its finder line.
 
 ## Done when
 
 `setup --apply` on a machine with the plugin installed says so and names the remedy before it
-writes; the leaf refuses every `NETWORK_PATHS` spelling before any
-syscall **through both input paths — `homeOverride` and the env chain production actually
-takes**; an empty `HOME` returns `null` rather than reading a cwd-relative `.claude/settings.json`;
-no test reads a real home; the key clamp rejects a newline/ANSI suffix; doctor's existing
-duplication warn is pinned; typecheck + the CLI and shared suites green. The PR body records the
-refutation with the `git show` citation.
-
-**"The predicate exists once" is deliberately NOT a done-when.** No listed spec would red if the
-implementation added the leaf and left `evaluateTandemPlugin`'s inline
-`Object.entries(...).find(...)` in place: the duplication-warn pin at the end of Tests asserts
-behaviour that is identical either way. Making it checkable means a source-read assertion in the
-shape of `tests/cli/doctor-path-safety.test.ts:694-717` (`src/cli/doctor.ts` contains no
-`startsWith("tandem@")` outside the shared leaf), and this wave's minimal-fix bar does not buy new
-scanning machinery for a one-line substitution. The substitution stays in the Fix as a
-review-verified change; claiming it as a done-when nothing checks is the #1529 shape.
+writes, and still writes; no test reads a real home; the key clamp rejects a newline/ANSI suffix;
+doctor's existing duplication warn is pinned; typecheck + the CLI suite green. The PR body records
+the refutation with the `git show` citation.
 
 ## Not in scope
 
-A doctor `--fix` flag (a new CLI surface; not in the taken shape). README / wizard copy (docs
-drift is #1821 / the J2 group). Making `setup --apply` skip the MCP write. Anything about the
-plugin's own npx pin — that is #1790.
+A doctor `--fix` flag. README / wizard copy (docs drift is #1821 / the J2 group). Making
+`setup --apply` skip the MCP write. The plugin's own npx pin — that is #1790.
 
-**Consolidating the `<home>/.claude/settings.json` path derivation.** Three copies exist after
-this change (the leaf, `src/cli/doctor.ts:1996`, and the `SETTINGS_LEAF` literal at
-`tests/cli/doctor-path-safety.test.ts:127,261`). The right fix is
-`claudeCodeSettingsPath(opts: ClientConfigPathOptions)` in
-`src/shared/integrations/client-config-paths.ts` with both callers repointed — a refactor of a
-UNC-screened doctor path, which exceeds this group's minimal-fix bar and would land untested
-inside a `setup --apply` PR. This spec de-duplicates the **predicate** only and says so in the Fix
-rather than borrowing that file's doctrine.
+## For Bryan
 
-## Files touched
+The `<home>/.claude/settings.json` derivation is spelled out twice in `src/cli/doctor.ts`
+(`:1996` and the new detector) plus a `SETTINGS_LEAF` literal in
+`tests/cli/doctor-path-safety.test.ts:127,261`. The consolidation is
+`claudeCodeSettingsPath()` in `src/shared/integrations/client-config-paths.ts` with both callers
+repointed — a refactor of a UNC-screened doctor path, above this group's bar.
 
-`src/shared/integrations/tandem-plugin.ts` (new), `src/cli/doctor.ts`, `src/cli/setup.ts`,
-`tests/shared/integrations/tandem-plugin.test.ts` (new), `tests/cli/run-setup-apply.test.ts`,
-`tests/cli/doctor.test.ts`, `tests/cli/doctor-path-safety.test.ts`.
+## Review corrections (scope cut)
 
-## Review corrections (round 1)
+**Removed**
 
-**Adopted**
+- *The new `src/shared/integrations/tandem-plugin.ts` leaf* and everything it required: its own
+  `homeOverride` + `homedir()` home chain, its own `readFileSync`/`JSON.parse` reader, the raw and
+  derived UNC screens, the layering argument, and the extension of
+  `doctor-path-safety.test.ts`'s unfenced-reader fence (which the spec itself conceded could never
+  fail). Detection lives in `src/cli/doctor.ts`, where the screened reader, the home spelling and
+  the UNC guards already exist and are already tested. **All five outstanding findings on this spec
+  targeted that leaf's test specs and are moot at the root**: there is no empty-home `||`-vs-`??`
+  discriminator (no `homedir()` fallback exists), no lone-backslash derived-path spec to gate on
+  win32, and no eleven-row `NETWORK_PATHS` table whose red run would issue the SMB handshake #1417
+  exists to prevent — so no containment stub is needed either.
+- *The two-input-path UNC tables and the `node:fs` mocking apparatus* (`vi.hoisted` +
+  `vi.mock("node:fs")`, `homedir()` mocking). With no new reader there is nothing new to screen;
+  the specs above touch only a pure predicate and a scratch-home wiring path.
+- *Mocking `tandem-plugin.js` in `run-setup-apply.test.ts`.* A scratch `HOME`/`USERPROFILE` is
+  simpler, exercises the real code path, and fixes the machine-dependence of that file's four
+  existing specs at the same time.
+- *The three round-by-round correction logs.*
 
-- *`detectEnabledTandemPlugin()` is called from `applySetup` with no home seam, so the new read
-  hits the operator's real `~/.claude/settings.json` in every existing `run-setup-apply` spec and
-  the negative specs become machine-dependent* (raised twice). The Tests section now names the
-  seam explicitly: add `vi.mock("../../src/shared/integrations/tandem-plugin.js")` alongside the
-  existing `apply.js` mock in `tests/cli/run-setup-apply.test.ts`, with the notice specs asserted
-  against the stub. The `"(or setup.test.ts, whichever already drives applySetup with a scratch
-  home)"` parenthetical is deleted and replaced with a paragraph saying why nothing there does and
-  why the specs must not move there.
-- *No specified home-resolution order, and `homedir()` ignores `HOME` on Windows.* Pinned to
-  `opts.homeOverride ?? process.env.HOME ?? process.env.USERPROFILE ?? homedir()` with the reason
-  and the two conflicting in-repo spellings cited; new leaf specs stub `HOME` and `USERPROFILE`
-  separately.
-- *The UNC screen was specified on the derived path, not the raw home — the measured POSIX blind
-  spot `homeIsUnsafe` exists for* (raised twice). Now spelled as two screens, raw-then-backstop,
-  in `homeIsUnsafe`'s shape, with the `doctor.ts:654-684` measurement and the #1529 shape cited.
-  The single-case UNC spec is replaced by a table over `NETWORK_PATHS`, asserting the **syscall**
-  is not made rather than the return value — the standing rule in `tests/helpers/unc-fixtures.ts`.
-- *A second unfenced JSON reader of a Claude config, outside the file the existing fence scans.*
-  Fix now states which of the two options is taken and why: `readClaudeConfig` cannot be reused
-  (`src/shared/` importing from `src/cli/` inverts the layering), the `reason`-leak class is
-  structurally absent from a `string | null` leaf, and the fence's `SOURCE` set is extended to
-  include the new module so a future `readJson` there reds it. Added to Tests and Files touched.
+**Kept**
 
-**Not adopted**
-
-- *Thread `homeOverride` through `applySetup` as the seam* (the alternative offered by the same
-  finding). Mocking the module in `run-setup-apply.test.ts` is strictly safer — with the module
-  mocked no filesystem read happens at all, so the negative specs cannot depend on machine state
-  even by accident — and it adds no test-only parameter to a production CLI option bag. The leaf
-  keeps `homeOverride` for its own unit tests, which is where it earns its keep.
-
-## Review corrections (round 2)
-
-**Adopted**
-
-- **BLOCKING** *The pinned home-resolution chain used `??` and dropped the empty-home early
-  return, so it did not match the two sites it cited — and with `HOME=""` the leaf reads a
-  cwd-relative `.claude/settings.json` whose JSON key is then interpolated into a shell command
-  printed to the operator* (raised three times). The chain is now
-  `opts.homeOverride || process.env.HOME || process.env.USERPROFILE || homedir()` with an explicit
-  `if (!home) return null;`, matching `src/cli/doctor.ts:1972-1973`; the citation is corrected
-  (both sites use `||`, and `checkUserMcpConfig` at `:1106` passes `home || undefined`); the
-  `homeIsUnsafe` `home !== ""` carve-out is named as the reason the screen cannot cover this. New
-  leaf spec: both env vars `""`, no `homeOverride` → `null` and no `readFileSync`.
-- **BLOCKING** *The UNC table drives only `homeOverride`, but `applySetup` calls
-  `detectEnabledTandemPlugin()` with no argument — so an `opts.homeOverride`-only screen passes
-  all eleven rows with the production path unscreened.* The table is now two `it.each` blocks: one
-  over `homeOverride`, one setting `process.env.HOME` **and** `process.env.USERPROFILE` to the
-  hostile spelling and calling with no options — mirroring
-  `tests/cli/doctor-path-safety.test.ts:812-826` vs `:833-838`, whose `:857-860` records the
-  surviving mutation this shape exists for.
-- *"Let the read's own screen stand as a backstop" asserts a control that is not in the code — the
-  leaf's reader has no screen, and the one named belongs to `readClaudeConfig`, which the same
-  spec rules out.* Replaced with an explicit second screen in the leaf,
-  `if (rejectUnsafeWindowsPrefix(settingsPath) !== null) return null;` before the `readFileSync`,
-  plus a leaf spec driving `homeOverride: "\\"` (passes the raw screen, derives an unsafe path on
-  posix) asserting `readFileSync` is not called.
-- *The fence extension can never fail, so it adds no signal while reading as new protection*
-  (raised twice). `readJson` is module-private to `doctor.ts` (`src/cli/doctor.ts:514`) and the
-  layering rule forbids importing it, and the leaf reads with `readFileSync` — which the fence's
-  `/\breadJson\(([^)]*)\)/g` (`doctor-path-safety.test.ts:696-700`) cannot see. The extension is
-  kept but is now labelled **forward-looking only** in both the Fix and the Tests, with a sentence
-  saying what actually pins the leaf's reader.
-- *The spec prescribes `vi.spyOn(fs, "readFileSync")`, which this repo has measured as broken on
-  an ESM builtin namespace.* Reworded to `vi.hoisted` + `vi.mock("node:fs", …)`, citing the
-  documented rationale at `tests/cli/doctor-path-safety.test.ts:22-25`.
-
-**Not adopted**
-
-- None.
-
-## Review corrections (round 3)
-
-**Adopted**
-
-- **BLOCKING** *The "Empty home" spec was self-contradictory and non-discriminating: under the
-  `||` chain the same spec mandates, `""` does not win — `homedir()` does, the guard never fires,
-  and `readFileSync` IS called on the operator's real `~/.claude/settings.json`; mocking
-  `homedir()` to `""` instead makes both spellings pass identically* (raised twice). It is now two
-  specs. A `||`-chain fall-through spec mocks `homedir()` to a scratch temp dir, empties both env
-  vars and asserts the **positive** call on `join(scratchHome, ".claude", "settings.json")` — which
-  reds under `??`, since `??` stops at `""` and returns before any call. A separate empty-home spec
-  mocks `homedir()` to `""` and pins `if (!home) return null;` alone. A new bullet requires
-  `homedir()` to be mocked in this file at all, because it ignores an empty `USERPROFILE` and would
-  otherwise route every emptied-env spec at the operator's real profile. The Fix's rationale is
-  rewritten: the guard, not the operator, is the security control; `||` is chosen for parity with
-  `src/cli/doctor.ts:1972-1973`, and the empty-string case is a behaviour difference, not a hole.
-- **BLOCKING** *The derived-path UNC spec is POSIX-only and was ungated, so it reds against correct
-  code on this wave's Windows machine — and the likely "repair" deletes the only spec pinning that
-  screen* (raised twice). It is now `it.runIf(process.platform !== "win32")`, with the measurement
-  in the spec (`path.win32.join("\\", ".claude", "settings.json")` → `\.claude\settings.json`, a
-  single separator that `src/shared/windows-path-safety.ts:62-84` accepts) and the precedent's
-  one-line reason copied from `tests/cli/doctor-path-safety.test.ts:643-664` — its evidence is CI's
-  ubuntu job, not a local green. The two `NETWORK_PATHS` tables stay ungated.
-- **BLOCKING** *The prescribed `node:fs` mock delegates to the real `readFileSync`, so a red/TDD
-  run of the eleven UNC rows performs the SMB handshake #1417 exists to prevent.* The Tests section
-  now requires the leaf suite's mock to refuse hostile prefixes itself before delegating, with the
-  `rejectUnsafeWindowsPrefix` throw spelled out, mirroring the containment stub at
-  `tests/cli/doctor-path-safety.test.ts:64-83` and citing the incident recorded at `:64-77`.
-- *The leaf cites `client-config-paths.ts`'s "not a second hand-maintained copy" doctrine while
-  hand-rolling `<home>/.claude/settings.json`, leaving that rule in three copies.* The citation is
-  removed: the Fix now states the leaf de-duplicates the **predicate**, not the path, names all
-  three path copies, and Not-in-scope records `claudeCodeSettingsPath()` as the real fix with why it
-  is out of bounds for this group.
-- *An untrusted `enabledPlugins` key is interpolated into a shell command printed to the terminal
-  with no shape clamp.* `findEnabledTandemPluginKey` now returns the key only when it also matches
-  `/^tandem@[A-Za-z0-9._-]+$/`, with a leaf spec for newline/ANSI suffixes and a note that this
-  narrows the pre-existing surface at `src/cli/doctor.ts:1944` rather than adding a class.
-- *Done-when claims "the predicate exists once", and no listed spec would red if doctor kept its
-  inline copy.* The claim is dropped, with a paragraph saying what would make it checkable (a
-  source-read assertion in the shape of `doctor-path-safety.test.ts:694-717`) and why this wave's
-  minimal-fix bar does not buy it — leaving an unchecked done-when is the #1529 shape.
-
-**Not adopted**
-
-- None.
+The refutation of the issue's first half; the `setup --apply` notice with the write preserved; the
+value-not-truthiness predicate and any-marketplace matching; the key shape clamp (this fix is what
+newly prints that key to a terminal); the doctor duplication-warn pin.

--- a/docs/reviews/2026-09-02-v1-review/tracks/specs/F-doctor-1811.md
+++ b/docs/reviews/2026-09-02-v1-review/tracks/specs/F-doctor-1811.md
@@ -1,0 +1,91 @@
+# F-doctor — #1811 plugin + `tandem setup --apply` loads the `tandem_*` toolset twice
+
+Branch `fix/doctor-and-skill-version-skew-1806`. Closes #1811. Ledger:
+`docs/reviews/2026-09-02-v1-review/areas/skill-plugin.md:26`. No experiment (`[read]` row).
+Overlaps #1790 item 4 — the same condition, filed twice.
+
+## Problem
+
+**One of the issue's two halves is refuted by the source, and the spec says so rather than
+re-fixing it.** The cited `doctor.ts:1842-1845` at the review baseline `3fb6408` are the *doc
+comment* on `checkTandemPlugin` ("2. The plugin's MCP servers duplicate the ones setup writes"),
+not an emitter. The emitter is `evaluateTandemPlugin`'s second outcome, present unchanged at
+`3fb6408`: `status: "warn"`, message *"Both the Tandem plugin and a tandem MCP entry in
+~/.claude.json are present — the tandem_* tools will appear twice"*, `fix` naming the remedy
+`claude plugin uninstall ${installedKey}` with the key it actually found. So **doctor already
+detects the condition and already names the remedy.** Verified by `git show
+3fb6408:src/cli/doctor.ts | sed -n '1899,1912p'`.
+
+What is genuinely missing is the other half: **`tandem setup --apply` says nothing.** It detects
+targets, writes the `~/.claude.json` MCP entry and installs the skill without ever looking at
+`~/.claude/settings.json`, so the command that *creates* the duplication is the one surface that
+never mentions it. That is the fix here, and it is the shape the track file records
+(`F-push-paths-and-cli.md:22`: "`setup --apply` warns when the plugin is installed").
+
+## Fix
+
+- **New shared leaf `src/shared/integrations/tandem-plugin.ts`** (~30 lines), sibling of the
+  existing `client-config-paths.ts` — whose own doctrine comment ("Path from the shared leaf, so
+  doctor inspects the file `detectTargets` writes rather than a second hand-maintained copy of the
+  same rule") is the precedent for putting the predicate in one place instead of duplicating it:
+  - `findEnabledTandemPluginKey(enabledPlugins: Record<string, unknown> | null | undefined): string | null`
+    — pure; the predicate lifted verbatim from `evaluateTandemPlugin`:
+    `key.startsWith("tandem@") && value === true`. **Test the value, not truthiness** — `false` is
+    a deliberately disabled plugin — and match any marketplace suffix, because
+    `docs/spikes/plugin-delivery.md` recommends a local one and a hardcoded
+    `tandem@tandem-editor` in a remedy hands those users a command that errors.
+  - `detectEnabledTandemPlugin(opts: { homeOverride?: string } = {}): string | null` — resolves
+    `<home>/.claude/settings.json`, **refuses a UNC/device path first via
+    `rejectUnsafeWindowsPrefix` from `src/shared/windows-path-safety.ts`** (#1417: reading one
+    performs the SMB handshake that leaks an NTLM hash — the screen must precede the read, not
+    wrap it), then `readFileSync` + `JSON.parse` inside a total `try/catch`, and returns
+    `findEnabledTandemPluginKey(parsed.enabledPlugins)`. Every failure → `null`: absence is not
+    evidence, and this must never make `setup --apply` fail.
+- **`src/cli/doctor.ts`:** `evaluateTandemPlugin` calls `findEnabledTandemPluginKey(input.enabledPlugins)`
+  in place of its inline `Object.entries(...).find(...)`. One line, no behaviour change — it exists
+  so the two surfaces cannot drift. Doctor keeps its own reader, its own `homeIsUnsafe` screen and
+  its own reporting; it does **not** import `detectEnabledTandemPlugin`.
+- **`src/cli/setup.ts`, `applySetup`:** call `detectEnabledTandemPlugin()` once, immediately before
+  `console.error("Detecting Claude installations...")`, and when it returns a key print one
+  notice to stderr (setup's whole output is stderr):
+  `The Tandem plugin (<key>) is installed and already provides the tandem_* tools. Writing this
+  config too makes every tool appear twice — keep one: claude plugin uninstall <key>`.
+- **The write still happens.** `--apply` is the scriptable, non-interactive path whose contract is
+  "write the config"; silently skipping it would strand a user who later disables the plugin, with
+  no output saying why nothing was written. Warn, do not skip. (Assumption; the issue's own
+  suggestion offers skipping, the track file's taken shape says warn.)
+
+Rules that bite: **never against the real HOME** — the notice reads `~/.claude/settings.json`, so
+every test uses `homeOverride` or a scratch `HOME`/`USERPROFILE`. No config *writer* is added
+(#1599's bound and `tests/docs/config-writer-set-claims.test.ts` count durable write sites; this
+is a read). No new `/api` route, no MCP tool, no skill edit.
+
+## Tests
+
+- `tests/shared/integrations/tandem-plugin.test.ts` (new): `findEnabledTandemPluginKey` returns the
+  key for `{"tandem@tandem-editor": true}`; `null` for `{"tandem@x": false}` (kills a truthiness
+  check); `null` for `{"other@y": true}`; `null` for `null`/`undefined`/`{}`; returns the key for a
+  non-default marketplace `{"tandem@local-marketplace": true}` (kills a hardcoded suffix).
+  `detectEnabledTandemPlugin({ homeOverride })` against a temp home: absent file → `null`;
+  malformed JSON → `null` (no throw); `enabledPlugins` present → the key.
+- `tests/cli/setup.test.ts` (or `run-setup-apply.test.ts`, whichever already drives `applySetup`
+  with a scratch home): with a settings.json enabling `tandem@tandem-editor`, `--apply` prints a
+  notice containing `plugin uninstall` **and still writes the MCP entry** — the second assertion is
+  the discriminating one, killing a fix that "helpfully" skips the write. With `false`, and with no
+  settings.json at all, no notice is printed (kills a check that fires for every user).
+- `tests/cli/doctor.test.ts`: keep/add a pin that `evaluateTandemPlugin({ enabledPlugins:
+  {"tandem@tandem-editor": true}, wizardTandemEntry: true })` still yields the duplication `warn`
+  whose `fix` names `claude plugin uninstall tandem@tandem-editor` — the refuted half is a working
+  behaviour with no test of its own, and the refactor above touches its key-finding line.
+
+## Done when
+
+`setup --apply` on a machine with the plugin installed says so and names the remedy before it
+writes; the predicate exists once; doctor's existing duplication warn is pinned; typecheck + the
+CLI and shared suites green. The PR body records the refutation with the `git show` citation.
+
+## Not in scope
+
+A doctor `--fix` flag (a new CLI surface; not in the taken shape). README / wizard copy (docs
+drift is #1821 / the J2 group). Making `setup --apply` skip the MCP write. Anything about the
+plugin's own npx pin — that is #1790.

--- a/docs/reviews/2026-09-02-v1-review/tracks/specs/F-doctor-1811.md
+++ b/docs/reviews/2026-09-02-v1-review/tracks/specs/F-doctor-1811.md
@@ -38,19 +38,46 @@ never mentions it. That is the fix here, and it is the shape the track file reco
 
     **Home resolution is pinned, because the production call site passes no argument and the
     two spellings in this repo do not agree.** Use
-    `opts.homeOverride ?? process.env.HOME ?? process.env.USERPROFILE ?? homedir()` — the shape
-    `checkTandemPlugin` (`src/cli/doctor.ts:1972`) and `checkUserMcpConfig` (`:1107`) already
-    use. Its siblings in `apply.ts` (`:754`, `:2066`, `:2127`) use `opts.homeOverride ??
-    homedir()`, and `homedir()` reads `USERPROFILE` on Windows and ignores `HOME` — so a test
-    that stubs `HOME` alone would silently read the operator's real profile on the platform this
-    wave runs on. Writing the env reads explicitly is what makes both stubs work.
 
-    **Two UNC screens, not one — the derived path alone is not enough.** Screen the raw `home`
-    value **before** any `join`, in `homeIsUnsafe`'s shape
+    ```
+    const home = opts.homeOverride || process.env.HOME || process.env.USERPROFILE || homedir();
+    if (!home) return null;
+    ```
+
+    **`||` and the explicit empty-home return, not `??`** — the two cited sites are
+    `const home = process.env.HOME || process.env.USERPROFILE || "";` followed by `if (!home)
+    return;` (`checkTandemPlugin`, `src/cli/doctor.ts:1972-1973`; `checkUserMcpConfig` at `:1106`
+    passes `home || undefined` so `claudeCodeConfigPath` falls back to `homedir()`). `""` is not
+    nullish, so under `??` an empty `HOME` *wins* the chain, and the UNC screen below cannot catch
+    it: `homeIsUnsafe` is `home !== "" && rejectUnsafeWindowsPrefix(home) !== null`
+    (`src/cli/doctor.ts:681-683`), false for `""` **by construction** — which is exactly why
+    doctor pairs it with `if (!home) return`. The consequence is not abstract:
+    `join("", ".claude", "settings.json")` is **cwd-relative**, so `tandem setup --apply` run
+    inside any checkout would read *that repo's* `.claude/settings.json` — a file that exists in
+    this repo — and interpolate one of its JSON keys into the
+    `claude plugin uninstall <key>` command printed to the operator.
+
+    `apply.ts`'s siblings (`:754`, `:2066`, `:2127`) use `opts.homeOverride ?? homedir()`, and
+    `homedir()` reads `USERPROFILE` on Windows and ignores `HOME` — so a test that stubs `HOME`
+    alone would silently read the operator's real profile on the platform this wave runs on.
+    Writing the env reads explicitly is what makes both stubs work.
+
+    **Two UNC screens, not one — the derived path alone is not enough, and neither is the raw
+    value alone.** Screen the raw `home` value **before** any `join`, in `homeIsUnsafe`'s shape
     (`home !== "" && rejectUnsafeWindowsPrefix(home) !== null` — `rejectUnsafeWindowsPrefix` from
-    `src/shared/windows-path-safety.ts`), then resolve `<home>/.claude/settings.json` and let the
-    read's own screen stand as a backstop. `src/cli/doctor.ts:654-684` records the measurement
-    this comes from: of the fourteen spellings in `tests/helpers/unc-fixtures.ts`, four pure
+    `src/shared/windows-path-safety.ts`); then, after resolving
+    `<home>/.claude/settings.json`, run **a second explicit screen in the leaf**:
+    `if (rejectUnsafeWindowsPrefix(settingsPath) !== null) return null;` immediately before the
+    `readFileSync`. The round-1 text said "let the read's own screen stand as a backstop" — the
+    leaf's reader **has** no screen (that backstop belongs to `readClaudeConfig`,
+    `src/cli/doctor.ts:607`, which the layering rules out below), so shipping that sentence would
+    assert a control that is not in the code: #1417's own drift class. The measured POSIX case it
+    is there for is at `src/cli/doctor.ts:654-684`: a `$HOME` of a single backslash passes the raw
+    screen and derives `\/.claude/settings.json`.
+
+    That same block records the measurement the **raw**-value screen comes from, which is the
+    half a derived-path-only guard misses: of the fourteen spellings in
+    `tests/helpers/unc-fixtures.ts`, four pure
     forward-slash forms "collapse to a path this guard then accepts once `path.posix.join` has
     run". A derived-path-only screen therefore passes those rows on ubuntu — the only platform
     `check` runs — *because the path stopped being dangerous, not because anything screened it*:
@@ -72,7 +99,17 @@ never mentions it. That is the fix here, and it is the shape the track file reco
     upward inverts the layering. So **extend the fence's scan set instead**: make its `SOURCE`
     the concatenation of `src/cli/doctor.ts` and `src/shared/integrations/tandem-plugin.ts`, so a
     future `readJson(join(home, ".claude", "settings.json"))` added to the leaf reds the fence
-    rather than shipping unseen. Say so in the fence's comment.
+    rather than shipping unseen.
+
+    **Label the extension in the fence's comment as forward-looking only, because it cannot fail
+    today and must not be read as coverage of the reader this spec adds.** The fence matches
+    `readJson(` call sites (`tests/cli/doctor-path-safety.test.ts:696-700`); `readJson` is
+    module-private to `doctor.ts` (`src/cli/doctor.ts:514`, no `export`) and the layering rule
+    above forbids importing it, so no such call site can exist in the leaf. The leaf reads with
+    `readFileSync` + `JSON.parse`, which that regex can never see, and the positive control at
+    `:704` stays satisfied by `doctor.ts`'s own sites either way. What actually pins the leaf's
+    reader is the explicit `rejectUnsafeWindowsPrefix(settingsPath)` screen above plus the UNC
+    table below — not this fence.
 - **`src/cli/doctor.ts`:** `evaluateTandemPlugin` calls `findEnabledTandemPluginKey(input.enabledPlugins)`
   in place of its inline `Object.entries(...).find(...)`. One line, no behaviour change — it exists
   so the two surfaces cannot drift. Doctor keeps its own reader, its own `homeIsUnsafe` screen and
@@ -109,11 +146,40 @@ still made) is tested with the module mocked, so no real filesystem read happens
   - **Home resolution**, with no `homeOverride`: stub `HOME` to a temp dir carrying the settings
     file → the key; then unstub `HOME`, stub `USERPROFILE` to it → the key. Both stubs, because
     only one of them survives on each platform. `vi.unstubAllEnvs()` in `afterEach`.
-  - **UNC table**, driven over `NETWORK_PATHS` from `tests/helpers/unc-fixtures.ts` rather than a
-    single `\\\\host\\share` case: for every row, `detectEnabledTandemPlugin({ homeOverride: p })`
-    must make **no filesystem call**. Per that file's own standing rule, spy on `readFileSync` and
-    assert `not.toHaveBeenCalled()` — asserting the `null` return proves nothing, because the
-    unscreened code returns `null` too (the syscall throws).
+  - **Empty home** — the `||`-vs-`??` guard. With **no** `homeOverride` and both `HOME` and
+    `USERPROFILE` stubbed to `""`, `detectEnabledTandemPlugin()` returns `null` and the
+    `readFileSync` mock is `not.toHaveBeenCalled()`. Under `??` this reds: `""` wins the chain,
+    `homeIsUnsafe("")` is false by its own `home !== ""` clause, and the leaf reads a cwd-relative
+    `.claude/settings.json`. (`homedir()` must be mocked or the stubs must survive it — assert the
+    syscall, which is true either way.)
+  - **Derived-path screen** — the second UNC screen. `detectEnabledTandemPlugin({ homeOverride:
+    "\\" })` (a single backslash, the measured POSIX case at `src/cli/doctor.ts:654-684`): it
+    passes the raw screen and derives an unsafe path, so `readFileSync` must still be
+    `not.toHaveBeenCalled()`. This is the only spec that reds if the derived-path screen is
+    dropped in favour of the non-existent "backstop".
+  - **UNC table, twice — once per input path, because production takes the one the round-1 spec
+    did not drive.** `applySetup` calls `detectEnabledTandemPlugin()` with **no argument**, so its
+    real input is `process.env.HOME || USERPROFILE || homedir()`. A screen written as
+    `if (opts.homeOverride && rejectUnsafeWindowsPrefix(opts.homeOverride))` passes an
+    override-only table on all eleven rows while leaving a redirected `%USERPROFILE%` on a share —
+    the exact #1417 scenario — completely unscreened. Precedent for treating the env path as a
+    distinct guard site: `tests/cli/doctor-path-safety.test.ts:812-826` drives
+    `process.env.HOME`/`USERPROFILE` with the corpus separately from the `homeOverride` block at
+    `:833-838`, and `:857-860` records that a mutation removing the input screen survived the
+    whole suite. So, both driven over `NETWORK_PATHS` from `tests/helpers/unc-fixtures.ts` rather
+    than a single `\\\\host\\share` case:
+    - `it.each([...NETWORK_PATHS])` → `detectEnabledTandemPlugin({ homeOverride: p })`.
+    - `it.each([...NETWORK_PATHS])` → set `process.env.HOME` **and** `process.env.USERPROFILE` to
+      the hostile spelling and call `detectEnabledTandemPlugin()` with **no options**.
+
+    For every row of both, **no filesystem call**. Per `unc-fixtures.ts`'s standing rule, assert
+    the `readFileSync` spy `not.toHaveBeenCalled()` — asserting the `null` return proves nothing,
+    because the unscreened code returns `null` too (the syscall throws).
+  - **Mock `node:fs` with `vi.hoisted` + `vi.mock("node:fs", …)`, never `vi.spyOn(fs, …)`.** The
+    leaf imports `readFileSync` from `node:fs` directly and an ESM module namespace is not
+    configurable, so `vi.spyOn` **throws**. The technique and this exact rationale are documented
+    at `tests/cli/doctor-path-safety.test.ts:22-25` (same as
+    `tests/server/unc-guard-ordering.test.ts`); copy it.
 - `tests/cli/run-setup-apply.test.ts` — **this file, not `setup.test.ts`.** Add
   `vi.mock("../../src/shared/integrations/tandem-plugin.js", …)` alongside the existing
   `apply.js` mock (`:13-30`), stubbing `detectEnabledTandemPlugin`. That file mocks only
@@ -136,14 +202,18 @@ still made) is tested with the module mocked, so no real filesystem read happens
   whose `fix` names `claude plugin uninstall tandem@tandem-editor` — the refuted half is a working
   behaviour with no test of its own, and the refactor above touches its key-finding line.
 - `tests/cli/doctor-path-safety.test.ts`: extend the unfenced-reader fence's `SOURCE` to include
-  the new leaf, per the Fix.
+  the new leaf, per the Fix — **forward-looking only**, and the comment must say so. It cannot
+  fail for the reader this spec adds (`readJson` is private to `doctor.ts` and the leaf reads with
+  `readFileSync`), so it is not what pins the leaf; the two UNC screens and the tables above are.
 
 ## Done when
 
 `setup --apply` on a machine with the plugin installed says so and names the remedy before it
 writes; the predicate exists once; the leaf refuses every `NETWORK_PATHS` spelling before any
-syscall; no test reads a real home; doctor's existing duplication warn is pinned; typecheck + the
-CLI and shared suites green. The PR body records the refutation with the `git show` citation.
+syscall **through both input paths — `homeOverride` and the env chain production actually
+takes**; an empty `HOME` returns `null` rather than reading a cwd-relative `.claude/settings.json`;
+no test reads a real home; doctor's existing duplication warn is pinned; typecheck + the CLI and
+shared suites green. The PR body records the refutation with the `git show` citation.
 
 ## Not in scope
 
@@ -191,3 +261,43 @@ plugin's own npx pin — that is #1790.
   mocked no filesystem read happens at all, so the negative specs cannot depend on machine state
   even by accident — and it adds no test-only parameter to a production CLI option bag. The leaf
   keeps `homeOverride` for its own unit tests, which is where it earns its keep.
+
+## Review corrections (round 2)
+
+**Adopted**
+
+- **BLOCKING** *The pinned home-resolution chain used `??` and dropped the empty-home early
+  return, so it did not match the two sites it cited — and with `HOME=""` the leaf reads a
+  cwd-relative `.claude/settings.json` whose JSON key is then interpolated into a shell command
+  printed to the operator* (raised three times). The chain is now
+  `opts.homeOverride || process.env.HOME || process.env.USERPROFILE || homedir()` with an explicit
+  `if (!home) return null;`, matching `src/cli/doctor.ts:1972-1973`; the citation is corrected
+  (both sites use `||`, and `checkUserMcpConfig` at `:1106` passes `home || undefined`); the
+  `homeIsUnsafe` `home !== ""` carve-out is named as the reason the screen cannot cover this. New
+  leaf spec: both env vars `""`, no `homeOverride` → `null` and no `readFileSync`.
+- **BLOCKING** *The UNC table drives only `homeOverride`, but `applySetup` calls
+  `detectEnabledTandemPlugin()` with no argument — so an `opts.homeOverride`-only screen passes
+  all eleven rows with the production path unscreened.* The table is now two `it.each` blocks: one
+  over `homeOverride`, one setting `process.env.HOME` **and** `process.env.USERPROFILE` to the
+  hostile spelling and calling with no options — mirroring
+  `tests/cli/doctor-path-safety.test.ts:812-826` vs `:833-838`, whose `:857-860` records the
+  surviving mutation this shape exists for.
+- *"Let the read's own screen stand as a backstop" asserts a control that is not in the code — the
+  leaf's reader has no screen, and the one named belongs to `readClaudeConfig`, which the same
+  spec rules out.* Replaced with an explicit second screen in the leaf,
+  `if (rejectUnsafeWindowsPrefix(settingsPath) !== null) return null;` before the `readFileSync`,
+  plus a leaf spec driving `homeOverride: "\\"` (passes the raw screen, derives an unsafe path on
+  posix) asserting `readFileSync` is not called.
+- *The fence extension can never fail, so it adds no signal while reading as new protection*
+  (raised twice). `readJson` is module-private to `doctor.ts` (`src/cli/doctor.ts:514`) and the
+  layering rule forbids importing it, and the leaf reads with `readFileSync` — which the fence's
+  `/\breadJson\(([^)]*)\)/g` (`doctor-path-safety.test.ts:696-700`) cannot see. The extension is
+  kept but is now labelled **forward-looking only** in both the Fix and the Tests, with a sentence
+  saying what actually pins the leaf's reader.
+- *The spec prescribes `vi.spyOn(fs, "readFileSync")`, which this repo has measured as broken on
+  an ESM builtin namespace.* Reworded to `vi.hoisted` + `vi.mock("node:fs", …)`, citing the
+  documented rationale at `tests/cli/doctor-path-safety.test.ts:22-25`.
+
+**Not adopted**
+
+- None.

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -1117,7 +1117,12 @@ const HOME_CLAUDE_JSON = `~/.${"claude"}.json`;
  * `/api/diagnostics` filter, and the Report-a-bug link prefills a PUBLIC issue
  * body — while `redactUserPaths`, the only scrubber downstream, knows nothing
  * about URL userinfo or a query token. `type` goes through
- * {@link describeEntryType} for the same reason.
+ * {@link describeClampedValue} for the same reason.
+ *
+ * The one part of the url that is named is the SCHEME, and it is named because
+ * it can carry no secret: it is neither host, userinfo, path nor query, and it
+ * is what tells a reader why an otherwise-correct-looking entry is red. It
+ * goes through the same clamp.
  */
 /**
  * Hostnames a `tandem` MCP url may name. The server binds `127.0.0.1`, so
@@ -1138,7 +1143,7 @@ const HOME_CLAUDE_JSON = `~/.${"claude"}.json`;
 const LOOPBACK_MCP_HOSTNAMES = new Set(["127.0.0.1", "[::1]", "localhost"]);
 
 /**
- * Render an entry's `type` for the warn message.
+ * Render an entry's `type` — or a url's scheme — for the warn message.
  *
  * The warn arm below fires precisely when `type !== "http"`, i.e. precisely
  * when the value is NOT enum-shaped, so "it's an enum, print it verbatim" is
@@ -1149,10 +1154,15 @@ const LOOPBACK_MCP_HOSTNAMES = new Set(["127.0.0.1", "[::1]", "localhost"]);
  * length. So clamp it the way {@link detectEnabledTandemPluginKey} clamps the
  * plugin key, and report `(unexpected)` rather than echoing — the port arm
  * already prefers `(none)` over a raw value for the same reason.
+ *
+ * The scheme goes through the same clamp. It comes off a *parsed* `URL`, so
+ * control bytes are impossible there, but its length is not bounded and the
+ * clamp costs nothing — and reusing one renderer keeps the two fields of this
+ * message from drifting apart on the rule that governs both.
  */
-function describeEntryType(type: unknown): string {
-  if (type === undefined) return "(none)";
-  return typeof type === "string" && /^[A-Za-z0-9_-]{1,32}$/.test(type) ? type : "(unexpected)";
+function describeClampedValue(value: unknown): string {
+  if (value === undefined) return "(none)";
+  return typeof value === "string" && /^[A-Za-z0-9_-]{1,32}$/.test(value) ? value : "(unexpected)";
 }
 
 function validateUserTandemEntry(
@@ -1176,13 +1186,31 @@ function validateUserTandemEntry(
     }
   }
 
-  if (e.type !== "http" || parsed === null || !parsed.pathname.includes("/mcp")) {
+  // The scheme is part of this arm, not a separate one: Tandem's MCP server is
+  // plaintext HTTP on loopback, so `https://127.0.0.1:3479/mcp` clears the
+  // type, path, host and port checks while Claude Code's TLS handshake fails
+  // and no `tandem_*` tool ever appears — green in the file Claude Code
+  // consults while Claude Code cannot connect, which is #1807's own defect.
+  // Same remedy as the other two shapes here (`buildMcpEntries` writes
+  // `http://`), so the same arm is the honest home for it.
+  if (
+    e.type !== "http" ||
+    parsed === null ||
+    parsed.protocol !== "http:" ||
+    !parsed.pathname.includes("/mcp")
+  ) {
     // `pathHasMcp` is computed, not a hardcoded `false`: this arm also fires on
     // a bad `type` with a perfectly good `/mcp` path, where `false` would be a
-    // false statement in doctor's own output.
+    // false statement in doctor's own output. `scheme` is named for the same
+    // reason — without it an https url reports `type=http, pathHasMcp=true` and
+    // the warn names nothing the reader can act on.
     const pathHasMcp = parsed === null ? "(unparsable)" : String(parsed.pathname.includes("/mcp"));
+    // Scheme only — never the host, path, userinfo or query, which the
+    // redaction rule governing this whole message keeps out of doctor's output.
+    const scheme =
+      parsed === null ? "(unparsable)" : describeClampedValue(parsed.protocol.replace(/:$/, ""));
     return {
-      message: `${HOME_CLAUDE_JSON} tandem: unexpected config — type=${describeEntryType(e.type)}, pathHasMcp=${pathHasMcp}`,
+      message: `${HOME_CLAUDE_JSON} tandem: unexpected config — type=${describeClampedValue(e.type)}, scheme=${scheme}, pathHasMcp=${pathHasMcp}`,
       fix: setupApplyRemedy(cliAvailable()),
     };
   }

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -1103,7 +1103,71 @@ function checkMcpJson(r: Recorder, cwd: string, cliAvailable: CliAvailability): 
  */
 const HOME_CLAUDE_JSON = `~/.${"claude"}.json`;
 
-function checkUserMcpConfig(r: Recorder, cliAvailable: CliAvailability): void {
+/**
+ * Validate the user-level `tandem` entry the way the project-level twin
+ * already validates its own (#1807). Key presence alone read green while
+ * Claude Code could not connect: a leftover `type: "stdio"`, a URL with no
+ * `/mcp`, or a port left at 3479 after the server moved.
+ *
+ * Returns `null` when the entry is fine (or is not ours to judge), otherwise
+ * the warn's message and fix.
+ *
+ * NO message, fix or `data` bag may interpolate the `url` or any part of its
+ * path. `~/.claude.json` carries bearer tokens, `user-mcp-config` survives the
+ * `/api/diagnostics` filter, and the Report-a-bug link prefills a PUBLIC issue
+ * body — while `redactUserPaths`, the only scrubber downstream, knows nothing
+ * about URL userinfo or a query token. `type` stays verbatim (enum-shaped).
+ */
+function validateUserTandemEntry(
+  entry: unknown,
+  mcpPort: number,
+  cliAvailable: CliAvailability,
+): { message: string; fix?: string } | null {
+  const e = (entry ?? {}) as { type?: unknown; url?: unknown; command?: unknown };
+
+  // A stdio entry here is a hand-edit or a plugin-managed shape, and
+  // `reportEntryCommand` already owns its failure modes — warning "unexpected
+  // config" on top of that is a regression dressed as a fix.
+  if (typeof e.command === "string" && e.command.length > 0) return null;
+
+  let parsed: URL | null = null;
+  if (typeof e.url === "string") {
+    try {
+      parsed = new URL(e.url);
+    } catch {
+      parsed = null;
+    }
+  }
+
+  if (e.type !== "http" || parsed === null || !parsed.pathname.includes("/mcp")) {
+    // `pathHasMcp` is computed, not a hardcoded `false`: this arm also fires on
+    // a bad `type` with a perfectly good `/mcp` path, where `false` would be a
+    // false statement in doctor's own output.
+    const pathHasMcp = parsed === null ? "(unparsable)" : String(parsed.pathname.includes("/mcp"));
+    return {
+      message: `${HOME_CLAUDE_JSON} tandem: unexpected config — type=${String(e.type)}, pathHasMcp=${pathHasMcp}`,
+      fix: setupApplyRemedy(cliAvailable()),
+    };
+  }
+
+  // Compare the string form — `URL.port` is a string, so `!== mcpPort` would
+  // always be true — and treat a port-less URL as a mismatch: the entry must
+  // name Tandem's MCP port explicitly.
+  if (parsed.port !== String(mcpPort)) {
+    return {
+      message: `${HOME_CLAUDE_JSON} tandem: url names port ${parsed.port || "(none)"}, but Tandem's MCP port is ${mcpPort}`,
+      // Deliberately NOT `setupApplyRemedy`: `buildMcpEntries` hardcodes
+      // `MCP_URL` at the default port, so `setup --apply` rewrites the same
+      // wrong port and the warn re-fires forever — the dead-end-remedy defect
+      // this file has already been corrected for twice.
+      fix: `Edit the tandem entry's url in ${HOME_CLAUDE_JSON} to use port ${mcpPort}, or unset TANDEM_MCP_PORT and restart Tandem.`,
+    };
+  }
+
+  return null;
+}
+
+function checkUserMcpConfig(r: Recorder, cliAvailable: CliAvailability, mcpPort: number): void {
   const home = process.env.HOME || process.env.USERPROFILE || "";
   // Claude Code reads global MCP servers from ~/.claude.json (under
   // `mcpServers`), which is exactly where `tandem setup` writes them. The
@@ -1206,7 +1270,15 @@ function checkUserMcpConfig(r: Recorder, cliAvailable: CliAvailability): void {
   if (!servers.tandem) {
     r.warn("tandem not registered in ~/.claude.json", setupApplyRemedy(cliAvailable()));
   } else {
-    r.pass("tandem registered in ~/.claude.json");
+    const invalid = validateUserTandemEntry(servers.tandem, mcpPort, cliAvailable);
+    if (invalid) {
+      // `warn`, never `fail` — parity with the project-level twin. `tandem
+      // doctor` must not start exiting 1 on a machine whose tools arrive via
+      // the plugin.
+      r.warn(invalid.message, invalid.fix);
+    } else {
+      r.pass("tandem registered in ~/.claude.json");
+    }
     // Normally an HTTP entry here, which the helper ignores. A stdio entry in
     // this file means a hand-edit or a plugin-managed shape, and both can carry
     // the failure modes it reports.
@@ -2926,7 +2998,7 @@ export async function runDoctor(opts: RunDoctorOptions = {}): Promise<DoctorRepo
     recordEvaluation(r, evaluateAppTranslocation(process.execPath)),
   );
   await r.check("mcp-json", () => checkMcpJson(r, cwd, cliAvailable));
-  await r.check("user-mcp-config", () => checkUserMcpConfig(r, cliAvailable));
+  await r.check("user-mcp-config", () => checkUserMcpConfig(r, cliAvailable, mcpPort));
   await r.check("desktop-mcp-config", () =>
     checkDesktopMcpConfig(r, cliAvailable, opts.homeOverride),
   );

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -2045,16 +2045,11 @@ export function detectEnabledTandemPluginKey(): string | null {
 
 export function evaluateTandemPlugin(input: TandemPluginInput): EvalOutcome[] {
   if (input.enabledPlugins === null) return [];
-  // `false` is a real and common value — a plugin the user deliberately
-  // disabled — so test the VALUE, not just key presence. A truthiness check
-  // would report a disabled plugin as installed.
-  // Keep the KEY, not just the fact. Detection matches any marketplace
-  // (`tandem@<whatever>`) on purpose — `docs/spikes/plugin-delivery.md`
-  // recommends a local marketplace for the no-git path — so a hardcoded
-  // `tandem@tandem-editor` in the remedy hands those users a command that
-  // errors. The uninstall string has to name the plugin we actually found.
-  const installedKey = findEnabledTandemPluginKey(input.enabledPlugins) ?? undefined;
-  if (installedKey === undefined) return [];
+  // Keep the KEY, not just the fact: the uninstall string has to name the
+  // plugin we actually found. Why the value test and the open marketplace
+  // suffix are load-bearing is on {@link findEnabledTandemPluginKey}.
+  const installedKey = findEnabledTandemPluginKey(input.enabledPlugins);
+  if (installedKey === null) return [];
 
   const out: EvalOutcome[] = [
     {

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -1125,8 +1125,13 @@ const HOME_CLAUDE_JSON = `~/.${"claude"}.json`;
  * goes through the same clamp.
  */
 /**
- * Hostnames a `tandem` MCP url may name. The server binds `127.0.0.1`, so
- * anything else is either unreachable or somebody else's machine.
+ * Hostnames a `tandem` MCP url may name without a warn. The server binds
+ * `127.0.0.1` by default, so anything else is unreachable, somebody else's
+ * machine, or — the one case doctor cannot tell apart from its own shell — a
+ * deliberate `TANDEM_BIND_HOST` LAN bind. The warn's wording carries that
+ * caveat; the set does not widen for it, because doctor has no way to learn
+ * the bind host and a LAN IP it cannot verify is exactly the shape it must
+ * not certify green.
  *
  * `TAURI_HOSTNAME` is deliberately NOT here (round-2 review). It was, on the
  * grounds that the desktop WebView's own origin is that name — but this arm
@@ -1222,12 +1227,20 @@ function validateUserTandemEntry(
   // The message names the SHAPE, not the hostname: the redaction rule above
   // governs every part of this url, and an internal host name is exactly the
   // kind of thing the Report-a-bug prefill must not carry into a public issue.
+  //
+  // Still a warn, never a pass — but the sentence must be TRUE. The server
+  // listens on loopback only by DEFAULT: `TANDEM_BIND_HOST` (docs/configuration.md)
+  // binds it to a LAN address, and `server.ts` then puts the resolved LAN IP
+  // into the SDK's `allowedHosts`, so an entry naming that IP is a working
+  // setup. Doctor runs in the user's shell, which need not carry the server's
+  // env, so it cannot know which case this is — it says so rather than
+  // asserting "loopback-only" and prescribing a rewrite that breaks the LAN one.
   if (!LOOPBACK_MCP_HOSTNAMES.has(parsed.hostname)) {
     return {
-      message: `${HOME_CLAUDE_JSON} tandem: url names a non-loopback host — Tandem's MCP server is loopback-only`,
+      message: `${HOME_CLAUDE_JSON} tandem: url names a non-loopback host — Tandem's MCP server listens on loopback unless it was started with TANDEM_BIND_HOST`,
       // Not `setupApplyRemedy`: it rewrites the url at the DEFAULT port, so on
       // a moved MCP port it trades this warn for the port one below.
-      fix: `Edit the tandem entry's url in ${HOME_CLAUDE_JSON} to point at 127.0.0.1:${mcpPort} — a remote host on that port is not this Tandem.`,
+      fix: `If Tandem was not started with TANDEM_BIND_HOST, edit the tandem entry's url in ${HOME_CLAUDE_JSON} to point at 127.0.0.1:${mcpPort} — a remote host on that port is not this Tandem.`,
     };
   }
 

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -35,7 +35,7 @@ import {
   isRecordedPathGone,
   probeNodeBinary,
 } from "../server/integrations/node-binary.js";
-import { DEFAULT_MCP_PORT, DEFAULT_WS_PORT, TAURI_HOSTNAME } from "../shared/constants.js";
+import { DEFAULT_MCP_PORT, DEFAULT_WS_PORT } from "../shared/constants.js";
 import { isAppTranslocatedPath } from "../shared/integrations/app-translocation.js";
 import {
   claudeCodeConfigPath,
@@ -1116,15 +1116,44 @@ const HOME_CLAUDE_JSON = `~/.${"claude"}.json`;
  * path. `~/.claude.json` carries bearer tokens, `user-mcp-config` survives the
  * `/api/diagnostics` filter, and the Report-a-bug link prefills a PUBLIC issue
  * body — while `redactUserPaths`, the only scrubber downstream, knows nothing
- * about URL userinfo or a query token. `type` stays verbatim (enum-shaped).
+ * about URL userinfo or a query token. `type` goes through
+ * {@link describeEntryType} for the same reason.
  */
 /**
  * Hostnames a `tandem` MCP url may name. The server binds `127.0.0.1`, so
  * anything else is either unreachable or somebody else's machine.
- * `TAURI_HOSTNAME` is here because the desktop WebView's own origin is that
- * name — a config carrying it is odd but not an exfiltration shape.
+ *
+ * `TAURI_HOSTNAME` is deliberately NOT here (round-2 review). It was, on the
+ * grounds that the desktop WebView's own origin is that name — but this arm
+ * decides REACHABILITY, not only exfiltration shape, and the two do not agree.
+ * `server.ts` passes `allowedHosts` (the only list `tauri.localhost` is on)
+ * solely when a LAN IP resolved; on a default loopback bind it is `undefined`,
+ * so the SDK installs `localhostHostValidation()`, whose allowlist is exactly
+ * `localhost` / `127.0.0.1` / `[::1]`. Every `/mcp` request carrying
+ * `Host: tauri.localhost` is answered `403 Invalid Host`. Certifying that url
+ * green is #1807's own defect — a pass in the file Claude Code consults while
+ * Claude Code cannot connect — reintroduced by the arm added to prevent it.
+ * The WebView origin is a CORS/Origin concern; it is not an MCP url host.
  */
-const LOOPBACK_MCP_HOSTNAMES = new Set(["127.0.0.1", "[::1]", "localhost", TAURI_HOSTNAME]);
+const LOOPBACK_MCP_HOSTNAMES = new Set(["127.0.0.1", "[::1]", "localhost"]);
+
+/**
+ * Render an entry's `type` for the warn message.
+ *
+ * The warn arm below fires precisely when `type !== "http"`, i.e. precisely
+ * when the value is NOT enum-shaped, so "it's an enum, print it verbatim" is
+ * false on the one branch that prints it. `~/.claude.json` is arbitrary JSON
+ * from disk: a `\r`/`\x1b[2K` value repaints doctor's own warn line as a pass,
+ * a bare `\n` forges a second result line, and the value reaches
+ * `/api/diagnostics` and from there the Report-a-bug prefill unbounded in
+ * length. So clamp it the way {@link detectEnabledTandemPluginKey} clamps the
+ * plugin key, and report `(unexpected)` rather than echoing — the port arm
+ * already prefers `(none)` over a raw value for the same reason.
+ */
+function describeEntryType(type: unknown): string {
+  if (type === undefined) return "(none)";
+  return typeof type === "string" && /^[A-Za-z0-9_-]{1,32}$/.test(type) ? type : "(unexpected)";
+}
 
 function validateUserTandemEntry(
   entry: unknown,
@@ -1153,7 +1182,7 @@ function validateUserTandemEntry(
     // false statement in doctor's own output.
     const pathHasMcp = parsed === null ? "(unparsable)" : String(parsed.pathname.includes("/mcp"));
     return {
-      message: `${HOME_CLAUDE_JSON} tandem: unexpected config — type=${String(e.type)}, pathHasMcp=${pathHasMcp}`,
+      message: `${HOME_CLAUDE_JSON} tandem: unexpected config — type=${describeEntryType(e.type)}, pathHasMcp=${pathHasMcp}`,
       fix: setupApplyRemedy(cliAvailable()),
     };
   }

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -35,7 +35,7 @@ import {
   isRecordedPathGone,
   probeNodeBinary,
 } from "../server/integrations/node-binary.js";
-import { DEFAULT_MCP_PORT, DEFAULT_WS_PORT } from "../shared/constants.js";
+import { DEFAULT_MCP_PORT, DEFAULT_WS_PORT, TAURI_HOSTNAME } from "../shared/constants.js";
 import { isAppTranslocatedPath } from "../shared/integrations/app-translocation.js";
 import {
   claudeCodeConfigPath,
@@ -1118,6 +1118,14 @@ const HOME_CLAUDE_JSON = `~/.${"claude"}.json`;
  * body — while `redactUserPaths`, the only scrubber downstream, knows nothing
  * about URL userinfo or a query token. `type` stays verbatim (enum-shaped).
  */
+/**
+ * Hostnames a `tandem` MCP url may name. The server binds `127.0.0.1`, so
+ * anything else is either unreachable or somebody else's machine.
+ * `TAURI_HOSTNAME` is here because the desktop WebView's own origin is that
+ * name — a config carrying it is odd but not an exfiltration shape.
+ */
+const LOOPBACK_MCP_HOSTNAMES = new Set(["127.0.0.1", "[::1]", "localhost", TAURI_HOSTNAME]);
+
 function validateUserTandemEntry(
   entry: unknown,
   mcpPort: number,
@@ -1147,6 +1155,22 @@ function validateUserTandemEntry(
     return {
       message: `${HOME_CLAUDE_JSON} tandem: unexpected config — type=${String(e.type)}, pathHasMcp=${pathHasMcp}`,
       fix: setupApplyRemedy(cliAvailable()),
+    };
+  }
+
+  // Host BEFORE port: a remote host on the right port is the one shape this
+  // check must never certify — Claude Code would send every `tandem_*` call,
+  // document text included, to it — and reporting the port there would name
+  // the wrong field. `URL.hostname` renders IPv6 bracketed, hence `[::1]`.
+  // The message names the SHAPE, not the hostname: the redaction rule above
+  // governs every part of this url, and an internal host name is exactly the
+  // kind of thing the Report-a-bug prefill must not carry into a public issue.
+  if (!LOOPBACK_MCP_HOSTNAMES.has(parsed.hostname)) {
+    return {
+      message: `${HOME_CLAUDE_JSON} tandem: url names a non-loopback host — Tandem's MCP server is loopback-only`,
+      // Not `setupApplyRemedy`: it rewrites the url at the DEFAULT port, so on
+      // a moved MCP port it trades this warn for the port one below.
+      fix: `Edit the tandem entry's url in ${HOME_CLAUDE_JSON} to point at 127.0.0.1:${mcpPort} — a remote host on that port is not this Tandem.`,
     };
   }
 

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -2971,6 +2971,43 @@ export async function runDoctor(opts: RunDoctorOptions = {}): Promise<DoctorRepo
 
 // ── Printer + exit-code wrapper ─────────────────────────────────────
 
+/**
+ * Parse one port env var the way the *server* does, so doctor probes where the
+ * server actually binds.
+ *
+ * `parseInt(raw || String(fallback), 10)` deliberately mirrors
+ * `src/server/index.ts` — not `Number`, and not `backend-ports.ts`'s stricter
+ * `/^\d{1,5}$/`. The server binds `TANDEM_PORT=4918abc` on 4918, so a stricter
+ * parser here would re-create the false "server not running" for exactly the
+ * inputs the server accepts.
+ *
+ * The `1..65535` clamp is a probe-side decision, NOT a mirror of the server:
+ * `listen(0)` binds an OS-chosen ephemeral port, so `TANDEM_PORT=0` is not
+ * "input the server would reject" — it is undiagnosable from outside the
+ * process. Falling back to the default at least prints a port shape the user
+ * recognises.
+ */
+function envPort(raw: string | undefined, fallback: number): number {
+  const n = parseInt(raw || String(fallback), 10);
+  return Number.isInteger(n) && n >= 1 && n <= 65535 ? n : fallback;
+}
+
+/**
+ * The single resolution site for the two documented port overrides (#1806).
+ * `runDoctor` itself never reads them — an embedder that knows its live ports
+ * (the `/api/diagnostics` route) must not get the CLI's answer layered under
+ * its own.
+ */
+export function resolveDoctorPortsFromEnv(env: NodeJS.ProcessEnv = process.env): {
+  wsPort: number;
+  mcpPort: number;
+} {
+  return {
+    wsPort: envPort(env.TANDEM_PORT, DEFAULT_WS_PORT),
+    mcpPort: envPort(env.TANDEM_MCP_PORT, DEFAULT_MCP_PORT),
+  };
+}
+
 export interface RunDoctorCliOptions {
   json?: boolean;
 }
@@ -3002,7 +3039,7 @@ export async function runDoctorCli(opts: RunDoctorCliOptions = {}): Promise<numb
 
   let report: DoctorReport;
   try {
-    report = await runDoctor();
+    report = await runDoctor(resolveDoctorPortsFromEnv());
   } catch (err) {
     const message = errMsg(err);
     if (json) {

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -1986,6 +1986,63 @@ export interface TandemPluginInput {
   wizardTandemEntry: boolean;
 }
 
+/**
+ * The enabled `tandem@<marketplace>` key in `enabledPlugins`, or `null`.
+ *
+ * `value === true`, not truthiness: `false` is a real and common value — a
+ * plugin the user deliberately disabled — and a truthiness check would report
+ * it as installed. Any marketplace suffix matches on purpose
+ * (`docs/spikes/plugin-delivery.md` recommends a local one), so a hardcoded
+ * `tandem@tandem-editor` in a remedy would hand those users a command that
+ * errors.
+ *
+ * Returns the RAW key, unclamped. The key-shape clamp lives in
+ * {@link detectEnabledTandemPluginKey}, not here: `evaluateTandemPlugin`
+ * short-circuits both of its outcomes on an undefined key, so clamping here
+ * would make doctor stop reporting a plugin that is genuinely installed —
+ * a regression, not a hardening.
+ */
+export function findEnabledTandemPluginKey(
+  enabledPlugins: Record<string, unknown> | null,
+): string | null {
+  if (enabledPlugins === null) return null;
+  return (
+    Object.entries(enabledPlugins).find(
+      ([key, value]) => key.startsWith("tandem@") && value === true,
+    )?.[0] ?? null
+  );
+}
+
+/**
+ * Read `~/.claude/settings.json` and report the enabled Tandem plugin key, for
+ * the one surface that has to decide before doctor runs: `tandem setup --apply`
+ * warns that writing its own MCP entry loads the `tandem_*` toolset twice
+ * (#1811).
+ *
+ * Reuses `checkTandemPlugin`'s home spelling and its screened reader, so this
+ * adds no new reader, no second UNC screen (#1417) and no new home chain.
+ * Absence is never evidence, and this must never make `setup --apply` fail.
+ *
+ * **The key shape is clamped here**, because this fix is what newly prints the
+ * key into a terminal inside a copy-paste `claude plugin uninstall <key>`, and
+ * a newline or ANSI escape in arbitrary JSON-key text would render as something
+ * other than what it is. Suppressing the new notice for such a key costs
+ * nothing; suppressing doctor's existing report of an installed plugin would
+ * not.
+ */
+export function detectEnabledTandemPluginKey(): string | null {
+  const home = process.env.HOME || process.env.USERPROFILE || "";
+  if (!home || homeIsUnsafe(home)) return null;
+
+  const read = readClaudeConfig(join(home, ".claude", "settings.json"));
+  if (read.kind !== "ok") return null;
+
+  const key = findEnabledTandemPluginKey(
+    (read.value as { enabledPlugins?: Record<string, unknown> }).enabledPlugins ?? {},
+  );
+  return key !== null && /^tandem@[A-Za-z0-9._-]+$/.test(key) ? key : null;
+}
+
 export function evaluateTandemPlugin(input: TandemPluginInput): EvalOutcome[] {
   if (input.enabledPlugins === null) return [];
   // `false` is a real and common value — a plugin the user deliberately
@@ -1996,9 +2053,7 @@ export function evaluateTandemPlugin(input: TandemPluginInput): EvalOutcome[] {
   // recommends a local marketplace for the no-git path — so a hardcoded
   // `tandem@tandem-editor` in the remedy hands those users a command that
   // errors. The uninstall string has to name the plugin we actually found.
-  const installedKey = Object.entries(input.enabledPlugins).find(
-    ([key, value]) => key.startsWith("tandem@") && value === true,
-  )?.[0];
+  const installedKey = findEnabledTandemPluginKey(input.enabledPlugins) ?? undefined;
   if (installedKey === undefined) return [];
 
   const out: EvalOutcome[] = [

--- a/src/cli/setup.ts
+++ b/src/cli/setup.ts
@@ -198,8 +198,19 @@ async function applySetup(opts: SetupOptions): Promise<void> {
   // invocation (contrarian review S5), even when no targets were written.
   console.error("\nInstalling Claude Code skill...");
   try {
-    await installSkill();
-    console.error("  \x1b[32m✓\x1b[0m ~/.claude/skills/tandem/SKILL.md");
+    const result = await installSkill();
+    if (result?.written === false) {
+      // The remedy names DELETING the file, never "upgrade Tandem to move it":
+      // no Tandem version moves a `version: 999` file, so that would be a
+      // dead-end fix line.
+      console.error(
+        `  \x1b[33m⚠\x1b[0m kept the installed skill (v${result.onDiskVersion} on disk is newer ` +
+          `than this install's v${result.bundledVersion}) — delete ` +
+          "~/.claude/skills/tandem/SKILL.md and re-run to replace it",
+      );
+    } else {
+      console.error("  \x1b[32m✓\x1b[0m ~/.claude/skills/tandem/SKILL.md");
+    }
   } catch (err) {
     console.error(
       `  \x1b[33m⚠\x1b[0m Could not install skill: ${err instanceof Error ? err.message : String(err)}`,

--- a/src/cli/setup.ts
+++ b/src/cli/setup.ts
@@ -121,6 +121,29 @@ async function applySetup(opts: SetupOptions): Promise<void> {
     targets = targets.filter((t) => wanted.has(t.kind));
   }
 
+  // #1811 — the command that CREATES the duplication was the one surface that
+  // never mentioned it. Gated on a `claude-code` target because the plugin is a
+  // Claude Code plugin: `--target=claude-desktop` writes no Claude Code entry
+  // and duplicates nothing, so the notice there would be a false statement
+  // prescribing the uninstall of a working plugin. Dynamic import, mirroring
+  // `src/cli/index.ts`, so other `tandem setup` paths do not pay for doctor's
+  // dependency graph.
+  //
+  // The write still happens: `--apply` is the scriptable path whose contract is
+  // "write the config", and silently skipping would strand a user who later
+  // disables the plugin with no output saying why.
+  if (targets.some((t) => t.kind === "claude-code")) {
+    const pluginKey = (await import("./doctor.js")).detectEnabledTandemPluginKey();
+    if (pluginKey !== null) {
+      console.error(
+        `\n  \x1b[33m⚠\x1b[0m The Tandem plugin (${pluginKey}) is installed and already provides ` +
+          "the tandem_* tools.\n" +
+          "    Writing this config too makes every tool appear twice — keep one:\n" +
+          `    claude plugin uninstall ${pluginKey}`,
+      );
+    }
+  }
+
   let outcome: WriteOutcome = { failures: 0, refusals: [], shimRegisteredFor: [] };
   if (targets.length === 0) {
     // `detectTargets` returns an empty list for two very different reasons, and

--- a/src/cli/setup.ts
+++ b/src/cli/setup.ts
@@ -199,7 +199,7 @@ async function applySetup(opts: SetupOptions): Promise<void> {
   console.error("\nInstalling Claude Code skill...");
   try {
     const result = await installSkill();
-    if (result?.written === false) {
+    if (!result.written) {
       // The remedy names DELETING the file, never "upgrade Tandem to move it":
       // no Tandem version moves a `version: 999` file, so that would be a
       // dead-end fix line.

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -776,7 +776,7 @@ async function main() {
       console.error("[Tandem] Hocuspocus startup error:", err);
     });
 
-    await startMcpServerStdio();
+    await startMcpServerStdio({ wsPort, mcpPort });
     console.error("[Tandem] MCP server running on stdio");
   }
 }

--- a/src/server/integrations/api-routes.ts
+++ b/src/server/integrations/api-routes.ts
@@ -38,7 +38,9 @@
  * - Resolves `tokenSecretRef` via `deps.keychain.getSecret(ref)` per entry.
  * - Calls `applyConfig` with explicit `{ create, remove }` ops built from
  *   the user's confirmation diff (passed via the wizard's persist call).
- * - Calls `installSkill()` exactly once after the per-integration loop.
+ * - Calls `installSkill()` exactly once after the per-integration loop, and
+ *   records a declined install (#1790, newer skill on disk) on the
+ *   skill-refresh error channel — the response shape does not carry it.
  * - Response never echoes entries / headers / tokens.
  */
 
@@ -96,6 +98,7 @@ import {
   type McpEntry,
   PathRejectedError,
   type RemovableEntry,
+  recordSkillInstallOutcome,
   shouldRegisterChannelShim,
 } from "./apply.js";
 import {
@@ -1005,7 +1008,18 @@ function makeApplyHandler(deps: IntegrationsRoutesDeps): Handler {
       // Skill install runs once if anything applied (per-user side effect).
       if (anyApplied) {
         try {
-          await (deps.installSkill ?? installSkill)();
+          const skill = await (deps.installSkill ?? installSkill)();
+          // A decline (#1790: a NEWER skill is on disk) is not a failed
+          // integration, so the response shape stays as it is — but it must
+          // not vanish either. It rides the refresher's error channel, which
+          // `GET /api/launcher/status` already surfaces and the client already
+          // renders; before this, only the refresher ever set it.
+          recordSkillInstallOutcome(skill);
+          if (!skill.written) {
+            console.error(
+              `[Tandem] apply: kept the installed skill (v${skill.onDiskVersion} on disk is newer than this install's v${skill.bundledVersion})`,
+            );
+          }
         } catch (err) {
           // Non-fatal; log only.
           console.error("[Tandem] apply: skill install failed:", err);

--- a/src/server/integrations/apply.ts
+++ b/src/server/integrations/apply.ts
@@ -2061,14 +2061,55 @@ async function maybeBackupExistingConfig(
  * `homeOverride` is supported for tests only — the apply HTTP handler
  * MUST NOT thread this from the request body. Same symlink/realpath
  * hardening as `applyConfig`.
+ *
+ * **It compares before writing (#1790).** An OLDER npm `tandem setup --apply`
+ * — which doctor prescribes for several conditions — used to silently downgrade
+ * a newer installed skill.
  */
-export async function installSkill(opts: { homeOverride?: string } = {}): Promise<void> {
+export async function installSkill(
+  opts: { homeOverride?: string } = {},
+): Promise<SkillInstallResult> {
   const home = opts.homeOverride ?? homedir();
   const skillPath = join(home, ".claude", "skills", "tandem", "SKILL.md");
   assertPathSafe(skillPath, { allowedRoots: opts.homeOverride ? [opts.homeOverride] : undefined });
   await mkdir(dirname(skillPath), { recursive: true });
+
+  // Strictly `>`, not the refresher's `>=`. That belongs to the silent
+  // background path; this is the authoritative, consent-bearing installer, and
+  // equal is what almost every run is — `>=` would tell a current user that v15
+  // is newer than v15, and would remove today's repair path for a hand-mangled
+  // SKILL.md that still carries the current version.
+  //
+  // ENOENT falls through to the write: this is the CREATE path, the one thing
+  // it must not inherit from the refresher. Any other read error also falls
+  // through, preserving today's behaviour. An unstamped bundle
+  // (`BUNDLED_SKILL_VERSION === 0`) cannot be compared, so it writes.
+  if (BUNDLED_SKILL_VERSION !== 0) {
+    try {
+      const current = await readFile(skillPath, "utf8");
+      const onDiskVersion = readSkillVersion(current);
+      if (onDiskVersion > BUNDLED_SKILL_VERSION) {
+        return { written: false, onDiskVersion, bundledVersion: BUNDLED_SKILL_VERSION };
+      }
+    } catch {
+      // Fall through to the write.
+    }
+  }
+
   await atomicWrite(SKILL_CONTENT, skillPath);
+  return { written: true };
 }
+
+/**
+ * What {@link installSkill} did. The `written: false` arm exists so the caller
+ * can say why nothing changed — it is the return half of the injected
+ * `installSkill` seam in `IntegrationsRoutesDeps`, so do not widen it to
+ * `Promise<unknown>` to silence a retype: that erases the contract keeping the
+ * real `~/.claude/skills/tandem/SKILL.md` out of the suite (#1894).
+ */
+export type SkillInstallResult =
+  | { written: true }
+  | { written: false; onDiskVersion: number; bundledVersion: number };
 
 /** Parse the integer `version:` from a skill front-matter block. Returns 0
  * if the file doesn't exist, has no version, or fails to parse — older

--- a/src/server/integrations/apply.ts
+++ b/src/server/integrations/apply.ts
@@ -2140,6 +2140,32 @@ export function _resetSkillRefreshErrorForTests(): void {
 }
 
 /**
+ * Record what the wizard's {@link installSkill} did on the same channel the
+ * refresher uses, so `GET /api/launcher/status` can say it. The apply route
+ * answers 200 with every integration `applied` either way — a declined skill
+ * is not a failed integration — but without this the decline (#1790) was
+ * visible nowhere: only the refresher set `lastSkillRefreshError`, and the
+ * route discarded the result. A write clears the record for the same reason
+ * the refresher's does: the file was just brought to the bundled version.
+ */
+export function recordSkillInstallOutcome(result: SkillInstallResult): void {
+  if (result.written) {
+    lastSkillRefreshError = null;
+    return;
+  }
+  // Same wording and the same delete-the-file remedy as `tandem setup --apply`
+  // prints: no Tandem version moves a `version: 999` file, so "upgrade Tandem"
+  // would be a dead-end fix line.
+  lastSkillRefreshError = {
+    code: "newer-on-disk",
+    message:
+      `kept the installed skill (v${result.onDiskVersion} on disk is newer than this ` +
+      `install's v${result.bundledVersion}) — delete ~/.claude/skills/tandem/SKILL.md and ` +
+      "re-run to replace it",
+  };
+}
+
+/**
  * Idempotently refresh an existing setup-managed skill.
  *
  * Compares the bundled `version:` against the on-disk file. Writes only

--- a/src/server/mcp/server.ts
+++ b/src/server/mcp/server.ts
@@ -5,6 +5,7 @@ import { createMcpExpressApp } from "@modelcontextprotocol/sdk/server/express.js
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
+import type { Transport } from "@modelcontextprotocol/sdk/shared/transport.js";
 import { isInitializeRequest } from "@modelcontextprotocol/sdk/types.js";
 import { randomUUID } from "crypto";
 import type { Server } from "http";
@@ -399,10 +400,28 @@ export function getPinnedMcpSessionCount(): number {
   return (sessions?.list() ?? []).filter((entry) => entry.openStreams > 0).length;
 }
 
-/** Start the MCP server on stdio (legacy, used as fallback via TANDEM_TRANSPORT=stdio). */
-export async function startMcpServerStdio(): Promise<void> {
-  const server = createMcpServer({ version: APP_VERSION, transport: "stdio" });
-  const transport = new StdioServerTransport();
+/**
+ * Start the MCP server on stdio (legacy, used as fallback via TANDEM_TRANSPORT=stdio).
+ *
+ * `ports` are the live `TANDEM_PORT` / `TANDEM_MCP_PORT` values `index.ts`
+ * resolves once — the same ones the HTTP path threads into its diagnostics
+ * deps. Without them `tandem_diagnostics` in stdio mode probed the DEFAULT
+ * ports on a moved install, reported them not listening and prescribed a
+ * second instance (#1806's server-side twin). Nothing here re-parses env.
+ *
+ * `transport` is a test seam: an `InMemoryTransport` in place of the process
+ * stdio, so a test can call `tandem_diagnostics` and see what was threaded.
+ */
+export async function startMcpServerStdio(
+  ports: { wsPort: number; mcpPort: number },
+  transport: Transport = new StdioServerTransport(),
+): Promise<void> {
+  const server = createMcpServer({
+    version: APP_VERSION,
+    transport: "stdio",
+    wsPort: ports.wsPort,
+    mcpPort: ports.mcpPort,
+  });
   await server.connect(transport);
 }
 

--- a/src/shared/launcher/contract.ts
+++ b/src/shared/launcher/contract.ts
@@ -115,7 +115,13 @@ export type LauncherErrorCode =
  * has no other signal that the skill is stale, so `/status` surfaces this
  * for the palette/settings UI to convert into a notification. */
 export interface SkillRefreshError {
-  code: "write-failed" | "read-failed" | "path-rejected" | "timed-out";
+  /**
+   * `newer-on-disk` is the wizard's, not the refresher's: `installSkill()`
+   * declined to downgrade a newer installed skill (#1790), and without this
+   * record `POST /api/integrations/apply` answered 200 with every integration
+   * `applied` while nothing anywhere said the skill was left alone.
+   */
+  code: "write-failed" | "read-failed" | "path-rejected" | "timed-out" | "newer-on-disk";
   message: string;
 }
 

--- a/tests/cli/doctor.test.ts
+++ b/tests/cli/doctor.test.ts
@@ -2313,6 +2313,15 @@ describe("checkUserMcpConfig wiring (~/.claude.json)", () => {
 
       const warn = await userMcpResult();
       expect(warn?.message).toContain("non-loopback host");
+      // Post-ship review: "loopback-only" was false under `TANDEM_BIND_HOST`
+      // (docs/configuration.md), so a user who deliberately bound to the LAN
+      // and pointed `~/.claude.json` at that IP was told to break a working
+      // setup. Doctor cannot see the server's env from the user's shell, so
+      // the sentence and the remedy both carry the condition instead.
+      expect(warn?.message).toContain("unless it was started with TANDEM_BIND_HOST");
+      expect(warn?.message).not.toContain("loopback-only");
+      expect(warn?.fix).toMatch(/^If Tandem was not started with TANDEM_BIND_HOST, /);
+      expect(warn?.fix).toContain("127.0.0.1:3479");
       // Names the shape, not the hostname: this message rides the same
       // redaction rule as the rest, and the fix must not be the dead-end
       // `setup --apply` (it rewrites the DEFAULT port).

--- a/tests/cli/doctor.test.ts
+++ b/tests/cli/doctor.test.ts
@@ -2245,6 +2245,36 @@ describe("checkUserMcpConfig wiring (~/.claude.json)", () => {
       expect(warn?.fix).not.toMatch(/setup --apply/);
     });
 
+    // The one shape a green verdict would be worst on: right type, right
+    // path, right port, someone else's machine. Claude Code would send every
+    // `tandem_*` call — `tandem_getTextContent` output, `tandem_edit` payloads
+    // — to that host.
+    it.each([
+      ["a remote host on the expected port", "http://attacker.example:3479/mcp"],
+      ["a LAN address", "http://192.168.1.9:3479/mcp"],
+    ])("warns on %s", async (_label, url) => {
+      writeEntry({ type: "http", url });
+
+      const warn = await userMcpResult();
+      expect(warn?.message).toContain("non-loopback host");
+      // Names the shape, not the hostname: this message rides the same
+      // redaction rule as the rest, and the fix must not be the dead-end
+      // `setup --apply` (it rewrites the DEFAULT port).
+      expect(JSON.stringify(await userMcpAll())).not.toContain(new URL(url).hostname);
+      expect(warn?.fix).not.toMatch(/setup --apply/);
+    });
+
+    it.each([
+      ["127.0.0.1", "http://127.0.0.1:3479/mcp"],
+      ["localhost", "http://localhost:3479/mcp"],
+      ["bracketed IPv6 loopback", "http://[::1]:3479/mcp"],
+    ])("still passes the loopback form %s", async (_label, url) => {
+      writeEntry({ type: "http", url });
+
+      const results = await userMcpAll();
+      expect(results.some((x) => x.message === "tandem registered in ~/.claude.json")).toBe(true);
+    });
+
     it.each([
       ["userinfo and a query token", "http://tok:s3cret@example.invalid:9999/mcp?key=abc"],
       ["a secret path segment", "http://example.invalid:9999/mcp/s3cret"],

--- a/tests/cli/doctor.test.ts
+++ b/tests/cli/doctor.test.ts
@@ -46,6 +46,7 @@ import {
   isTandemEditorRepo,
   MIN_NODE_VERSION,
   probeTandemEditorRepo,
+  resolveDoctorPortsFromEnv,
   runDoctor,
   runDoctorCli,
   setupApplyRemedy,
@@ -2438,4 +2439,124 @@ describe("checkNodeVersion wiring (via runDoctor(), not the pure evaluator)", ()
     // `failures` — so "warn" is what keeps `tandem doctor` at exit 0 on an
     // install that works.
   });
+});
+
+// #1806 — `tandem doctor` ignored TANDEM_PORT / TANDEM_MCP_PORT, so a user who
+// moved the server with the documented env vars got "server not running" plus a
+// remedy that starts a SECOND instance on the defaults.
+describe("resolveDoctorPortsFromEnv (#1806)", () => {
+  let home: string;
+
+  beforeEach(() => {
+    // The two wiring specs below run the WHOLE doctor, including
+    // `checkUserMcpConfig` and `checkTandemPlugin`, which read HOME/USERPROFILE
+    // directly — `runDoctorCli` has no `homeOverride` seam. Both variables,
+    // because `homedir()` reads USERPROFILE on Windows.
+    home = mkdtempSync(join(tmpdir(), "tandem-doctor-ports-"));
+    vi.stubEnv("HOME", home);
+    vi.stubEnv("USERPROFILE", home);
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    rmSync(home, { recursive: true, force: true });
+  });
+
+  it.each([
+    ["an explicit port", { TANDEM_PORT: "4918" }, 4918, 3479],
+    ["nothing set", {}, 3478, 3479],
+    // The `||` arm — which is why the server's `parseInt(raw || fallback)`
+    // spelling matters and `Number(raw)` would not do.
+    ["an empty string", { TANDEM_PORT: "" }, 3478, 3479],
+    // The server binds 4918abc on 4918; a stricter parser here would re-create
+    // the false "not running" for an input the server accepts.
+    ["a trailing-garbage port", { TANDEM_PORT: "4918abc" }, 4918, 3479],
+    ["an unparseable port", { TANDEM_PORT: "abc" }, 3478, 3479],
+    // The probe-side clamp: `listen(0)` is undiagnosable from outside.
+    ["zero", { TANDEM_PORT: "0" }, 3478, 3479],
+    ["an out-of-range port", { TANDEM_PORT: "70000" }, 3478, 3479],
+    ["the MCP override", { TANDEM_MCP_PORT: "4919" }, 3478, 4919],
+    ["both overrides", { TANDEM_PORT: "4918", TANDEM_MCP_PORT: "4919" }, 4918, 4919],
+  ])("resolves %s", (_label, env, wsPort, mcpPort) => {
+    expect(resolveDoctorPortsFromEnv(env as NodeJS.ProcessEnv)).toEqual({ wsPort, mcpPort });
+  });
+
+  /**
+   * An HTTP listener that answers immediately, NOT a bare `net` server:
+   * `runDoctor` runs `checkHealth` whenever the MCP probe succeeds, and
+   * `httpGet` waits 3s for a socket that never replies.
+   */
+  async function listenEphemeral(): Promise<{ port: number; close(): Promise<void> }> {
+    const server = createServer((_req, res) => {
+      res.writeHead(404);
+      res.end();
+    });
+    const port = await new Promise<number>((resolve) => {
+      server.listen(0, "127.0.0.1", () => {
+        const addr = server.address();
+        resolve(typeof addr === "object" && addr ? addr.port : 0);
+      });
+    });
+    return {
+      port,
+      close: () => new Promise<void>((resolve) => server.close(() => resolve())),
+    };
+  }
+
+  async function portsMessage(): Promise<string> {
+    const chunks: string[] = [];
+    const stdoutSpy = vi.spyOn(process.stdout, "write").mockImplementation((chunk: unknown) => {
+      chunks.push(String(chunk));
+      return true;
+    });
+    try {
+      await runDoctorCli({ json: true });
+    } finally {
+      stdoutSpy.mockRestore();
+    }
+    const parsed = JSON.parse(chunks.join(""));
+    const ports = parsed.results.find((x: { check: string }) => x.check === "ports");
+    return String(ports?.message ?? "");
+  }
+
+  // Generous budget: these drive the real doctor end to end, including
+  // `cliAvailable`'s PATH walk (~335 `statSync` calls) on top of the probes.
+  const WIRING_TIMEOUT_MS = timeoutMs(20_000, 60_000);
+
+  it(
+    "runDoctorCli probes the TANDEM_PORT the server would bind",
+    async () => {
+      const listener = await listenEphemeral();
+      try {
+        vi.stubEnv("TANDEM_PORT", String(listener.port));
+        const message = await portsMessage();
+        // Word boundaries, never `toContain`: ephemeral ports like 33478 or
+        // 34780 contain "3478" and the kernel picks which one we get.
+        expect(message).toMatch(new RegExp(String.raw`\b${listener.port}\b`));
+        expect(message).not.toMatch(/\b3478\b/);
+      } finally {
+        await listener.close();
+      }
+    },
+    WIRING_TIMEOUT_MS,
+  );
+
+  it(
+    "runDoctorCli probes the TANDEM_MCP_PORT the server would bind",
+    async () => {
+      const listener = await listenEphemeral();
+      try {
+        vi.stubEnv("TANDEM_MCP_PORT", String(listener.port));
+        const message = await portsMessage();
+        expect(message).toMatch(new RegExp(String.raw`\b${listener.port}\b`));
+        // 3479 must be gone; 3478 is EXPECTED — the ws port is still the
+        // default, and `checkPorts` names it in both surviving branches.
+        expect(message).not.toMatch(/\b3479\b/);
+        expect(message).toMatch(/\b3478\b/);
+      } finally {
+        await listener.close();
+      }
+    },
+    WIRING_TIMEOUT_MS,
+  );
 });

--- a/tests/cli/doctor.test.ts
+++ b/tests/cli/doctor.test.ts
@@ -2226,6 +2226,33 @@ describe("checkUserMcpConfig wiring (~/.claude.json)", () => {
       expect(warn?.message).toContain("pathHasMcp=true");
     });
 
+    // Round-2 review. This arm fires precisely when `type` is NOT enum-shaped,
+    // so echoing it verbatim was echoing arbitrary JSON text from disk into a
+    // terminal, into `/api/diagnostics`, and from there into a PUBLIC
+    // Report-a-bug prefill. `\r\x1b[2K` repaints doctor's own warn as a pass;
+    // a bare `\n` forges a second result line.
+    it("clamps a control-byte type instead of echoing it", async () => {
+      const hostile = "\u001b[2K\r  \u001b[32m ok \u001b[0m tandem registered in ~/.claude.json\nx";
+      writeEntry({ type: hostile, url: "http://127.0.0.1:3479/mcp" });
+
+      const warn = await userMcpResult();
+      expect(warn?.message).toContain("type=(unexpected)");
+      expect(warn?.message).not.toContain(String.fromCharCode(27));
+      expect(warn?.message).not.toContain("\n");
+      // And nothing repainted itself as the pass line.
+      expect(
+        (await userMcpAll()).some((x) => x.message === "tandem registered in ~/.claude.json"),
+      ).toBe(false);
+    });
+
+    it("reports a missing type as (none), not the string undefined", async () => {
+      writeEntry({ url: "http://127.0.0.1:3479/mcp" });
+
+      const warn = await userMcpResult();
+      expect(warn?.message).toContain("type=(none)");
+      expect(warn?.message).not.toContain("undefined");
+    });
+
     it("warns on a url with no /mcp path, without echoing the url", async () => {
       writeEntry({ type: "http", url: "http://127.0.0.1:3479/" });
 
@@ -2262,6 +2289,21 @@ describe("checkUserMcpConfig wiring (~/.claude.json)", () => {
       // `setup --apply` (it rewrites the DEFAULT port).
       expect(JSON.stringify(await userMcpAll())).not.toContain(new URL(url).hostname);
       expect(warn?.fix).not.toMatch(/setup --apply/);
+    });
+
+    // Round-2 review. `tauri.localhost` was in the loopback host set on the
+    // grounds that the desktop WebView's origin is that name — but this arm
+    // decides reachability. `server.ts` allowlists that host only when a LAN
+    // IP resolved; on a default loopback bind the SDK's own
+    // `localhostHostValidation()` answers every `/mcp` request carrying
+    // `Host: tauri.localhost` with 403. Certifying it green is exactly the
+    // #1807 defect the arm exists to prevent.
+    it("warns on the Tauri WebView hostname, which the MCP server 403s", async () => {
+      writeEntry({ type: "http", url: "http://tauri.localhost:3479/mcp" });
+
+      const warn = await userMcpResult();
+      expect(warn?.message).toContain("non-loopback host");
+      expect(JSON.stringify(await userMcpAll())).not.toContain("tauri.localhost");
     });
 
     it.each([

--- a/tests/cli/doctor.test.ts
+++ b/tests/cli/doctor.test.ts
@@ -2261,6 +2261,35 @@ describe("checkUserMcpConfig wiring (~/.claude.json)", () => {
       expect(warn?.message).not.toContain("http://127.0.0.1:3479/");
     });
 
+    // Round-3 review. Every other arm passes on this entry — type is "http",
+    // the path carries /mcp, the host is loopback, the port is right — but
+    // Tandem's MCP server is plaintext HTTP, so Claude Code's TLS handshake
+    // fails and no `tandem_*` tool ever appears. Certifying it green is the
+    // #1807 defect itself: a pass in the file Claude Code consults while
+    // Claude Code cannot connect.
+    it.each([
+      ["https", "https://127.0.0.1:3479/mcp"],
+      ["ws", "ws://127.0.0.1:3479/mcp"],
+    ])("warns on the %s scheme, which the MCP server does not speak", async (scheme, url) => {
+      writeEntry({ type: "http", url });
+
+      const warn = await userMcpResult();
+      expect(warn?.message).toContain(`scheme=${scheme}`);
+      // Named, because `type=http, pathHasMcp=true` alone tells the reader
+      // nothing they can act on — but nothing else about the url is.
+      expect(JSON.stringify(await userMcpAll())).not.toContain("127.0.0.1:3479");
+      // Here `setup --apply` IS the remedy: `buildMcpEntries` writes `http://`.
+      expect(warn?.fix).toBeTruthy();
+    });
+
+    it("reports the scheme as (unparsable) when the url will not parse", async () => {
+      writeEntry({ type: "http", url: "not a url" });
+
+      const warn = await userMcpResult();
+      expect(warn?.message).toContain("scheme=(unparsable)");
+      expect(warn?.message).toContain("pathHasMcp=(unparsable)");
+    });
+
     it("warns on a port that disagrees with the probed MCP port, with a remedy that works", async () => {
       writeEntry({ type: "http", url: "http://127.0.0.1:9999/mcp" });
 

--- a/tests/cli/doctor.test.ts
+++ b/tests/cli/doctor.test.ts
@@ -30,6 +30,7 @@ const SCAN_CAP_TIMEOUT_MS = timeoutMs(90_000, 300_000);
 
 import {
   CWD_DEPENDENT_CHECKS,
+  detectEnabledTandemPluginKey,
   evaluateAbsentChannelEntry,
   evaluateAppTranslocation,
   evaluateClaudeCli,
@@ -41,6 +42,7 @@ import {
   evaluateSpawnedEntryCommand,
   evaluateStaleGlobal,
   evaluateTandemPlugin,
+  findEnabledTandemPluginKey,
   globalTandemEditorVersion,
   isNodeVersionSupported,
   isTandemEditorRepo,
@@ -1735,6 +1737,90 @@ describe("evaluateTandemPlugin", () => {
       expect(outcome.fix).toContain("claude plugin uninstall tandem@some-local-marketplace");
       expect(outcome.fix).not.toContain("tandem@tandem-editor");
     }
+  });
+
+  it("still names the uninstall remedy on the duplication warn (#1811)", () => {
+    // #1811's first half claims doctor documents the double toolset with no
+    // remedy. It does not: this warn has named `claude plugin uninstall <key>`
+    // since before the review baseline. Pinned because #1811 substitutes the
+    // finder line this outcome is derived from.
+    const out = evaluateTandemPlugin({
+      enabledPlugins: { "tandem@tandem-editor": true },
+      wizardTandemEntry: true,
+    });
+    const warn = out.find((o) => o.status === "warn");
+    expect(warn?.message).toContain("twice");
+    expect(warn?.fix).toContain("claude plugin uninstall tandem@tandem-editor");
+  });
+});
+
+/** A raw ESC, built rather than typed — an escape byte in source is invisible. */
+const ESC = String.fromCharCode(27);
+
+describe("findEnabledTandemPluginKey (#1811)", () => {
+  it.each([
+    ["an enabled plugin", { "tandem@tandem-editor": true }, "tandem@tandem-editor"],
+    // A truthiness check would report a deliberately disabled plugin as installed.
+    ["a disabled plugin", { "tandem@x": false }, null],
+    ["someone else's plugin", { "other@y": true }, null],
+    ["an empty registry", {}, null],
+    ["no registry at all", null, null],
+    // A hardcoded suffix would miss the local-marketplace path
+    // `docs/spikes/plugin-delivery.md` recommends.
+    ["a local marketplace", { "tandem@local-marketplace": true }, "tandem@local-marketplace"],
+  ])("returns %s", (_label, plugins, expected) => {
+    expect(findEnabledTandemPluginKey(plugins)).toBe(expected);
+  });
+
+  it.each([
+    ["a newline suffix", "tandem@bad\nname"],
+    ["an ANSI suffix", `tandem@${ESC}[31mred`],
+  ])("is UNCLAMPED and still returns %s", (_label, key) => {
+    // The clamp deliberately does NOT live here: `evaluateTandemPlugin` returns
+    // [] on an undefined key, so rejecting a suffix here would silence doctor's
+    // report of a plugin that is genuinely installed — a regression, not a
+    // hardening.
+    expect(findEnabledTandemPluginKey({ [key]: true })).toBe(key);
+  });
+});
+
+describe("detectEnabledTandemPluginKey (#1811)", () => {
+  let home: string;
+
+  beforeEach(() => {
+    home = mkdtempSync(join(tmpdir(), "tandem-doctor-plugin-"));
+    vi.stubEnv("HOME", home);
+    vi.stubEnv("USERPROFILE", home);
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    rmSync(home, { recursive: true, force: true });
+  });
+
+  const writeSettings = (enabledPlugins: Record<string, unknown>) => {
+    mkdirSync(join(home, ".claude"), { recursive: true });
+    writeFileSync(join(home, ".claude", "settings.json"), JSON.stringify({ enabledPlugins }));
+  };
+
+  it("returns the key from ~/.claude/settings.json", () => {
+    writeSettings({ "tandem@tandem-editor": true });
+    expect(detectEnabledTandemPluginKey()).toBe("tandem@tandem-editor");
+  });
+
+  it("returns null when there is no settings file", () => {
+    expect(detectEnabledTandemPluginKey()).toBeNull();
+  });
+
+  it.each([
+    ["a newline suffix", "tandem@bad\nname"],
+    ["an ANSI suffix", `tandem@${ESC}[31mred`],
+  ])("clamps the key shape and rejects %s", (_label, key) => {
+    // This is the only place the clamp is asserted. It reds both a missing
+    // clamp and a clamp pushed down into the shared finder — `setup --apply`
+    // prints this key into a copy-paste `claude plugin uninstall <key>`.
+    writeSettings({ [key]: true });
+    expect(detectEnabledTandemPluginKey()).toBeNull();
   });
 });
 

--- a/tests/cli/doctor.test.ts
+++ b/tests/cli/doctor.test.ts
@@ -2027,6 +2027,9 @@ describe("checkUserMcpConfig wiring (~/.claude.json)", () => {
   beforeEach(() => {
     home = mkdtempSync(join(tmpdir(), "tandem-doctor-usermcp-"));
     vi.stubEnv("HOME", home);
+    // Both, so the specs are machine-independent on Windows, where `homedir()`
+    // reads USERPROFILE (#1807).
+    vi.stubEnv("USERPROFILE", home);
   });
 
   afterEach(() => {
@@ -2109,6 +2112,114 @@ describe("checkUserMcpConfig wiring (~/.claude.json)", () => {
     expect(warn?.message).toContain("not found");
     expect(warn?.fix).toContain("project-local .mcp.json");
     expect(warn?.fix).not.toContain("..");
+  });
+
+  // #1807 — the user level passed on key presence alone while its
+  // project-level twin validated the same entry, so a leftover install read
+  // green in the file Claude Code actually consults.
+  describe("validates the tandem entry, not just its presence (#1807)", () => {
+    const writeEntry = (tandem: unknown) => {
+      writeFileSync(
+        claudeCodeConfigPath({ homeOverride: home }),
+        JSON.stringify({ mcpServers: { tandem } }),
+      );
+    };
+
+    /** Every `user-mcp-config` outcome, stringified — `fix` and `data` too. */
+    const userMcpAll = async (opts: Parameters<typeof runDoctor>[0] = {}) => {
+      const report = await runDoctor(opts);
+      return report.results.filter((x) => x.check === "user-mcp-config");
+    };
+
+    it("warns on a stdio type, naming the computed pathHasMcp", async () => {
+      writeEntry({ type: "stdio", url: "http://127.0.0.1:3479/mcp" });
+
+      const warn = await userMcpResult();
+      expect(warn?.message).toContain("type=stdio");
+      // Computed, not a hardcoded `false`: the path really does carry /mcp.
+      expect(warn?.message).toContain("pathHasMcp=true");
+    });
+
+    it("warns on a url with no /mcp path, without echoing the url", async () => {
+      writeEntry({ type: "http", url: "http://127.0.0.1:3479/" });
+
+      const warn = await userMcpResult();
+      expect(warn?.message).toContain("pathHasMcp=false");
+      expect(warn?.message).not.toContain("http://127.0.0.1:3479/");
+    });
+
+    it("warns on a port that disagrees with the probed MCP port, with a remedy that works", async () => {
+      writeEntry({ type: "http", url: "http://127.0.0.1:9999/mcp" });
+
+      const warn = await userMcpResult();
+      expect(warn?.message).toContain("9999");
+      expect(warn?.message).toContain("3479");
+      // `setup --apply` rewrites the same hardcoded 3479, so prescribing it
+      // here would be a dead-end fix line for the condition being reported.
+      expect(warn?.fix).not.toMatch(/setup --apply/);
+    });
+
+    it.each([
+      ["userinfo and a query token", "http://tok:s3cret@example.invalid:9999/mcp?key=abc"],
+      ["a secret path segment", "http://example.invalid:9999/mcp/s3cret"],
+    ])("never echoes the url (%s)", async (_label, url) => {
+      writeEntry({ type: "http", url });
+
+      const results = await userMcpAll();
+      const serialized = JSON.stringify(results);
+      expect(results.some((x) => x.status === "warn")).toBe(true);
+      expect(serialized).not.toContain("s3cret");
+      expect(serialized).not.toContain("key=abc");
+      expect(serialized).not.toContain(url);
+    });
+
+    it("leaves a stdio (command) entry to reportEntryCommand and still passes", async () => {
+      writeEntry({ command: "/abs/node", args: [] });
+
+      const results = await userMcpAll();
+      // The positive: that pass is reachable only when the command arm returns
+      // null, so it reds both if the arm is dropped and if the validator
+      // returns null while emitting nothing at all.
+      expect(results.some((x) => x.message === "tandem registered in ~/.claude.json")).toBe(true);
+      // reportEntryCommand's own outcome still appears alongside it.
+      expect(results.length).toBeGreaterThan(1);
+    });
+
+    it("passes a healthy entry and says nothing about its url", async () => {
+      const url = "http://tok:s3cret@127.0.0.1:3479/mcp?key=abc";
+      writeEntry({ type: "http", url });
+
+      const results = await userMcpAll();
+      const serialized = JSON.stringify(results);
+      expect(results.some((x) => x.message === "tandem registered in ~/.claude.json")).toBe(true);
+      expect(serialized).not.toContain("s3cret");
+      expect(serialized).not.toContain("key=abc");
+      expect(serialized).not.toContain(url);
+    });
+
+    it("passes a plain healthy entry", async () => {
+      writeEntry({ type: "http", url: "http://127.0.0.1:3479/mcp" });
+
+      const results = await userMcpAll();
+      expect(results.some((x) => x.message === "tandem registered in ~/.claude.json")).toBe(true);
+    });
+
+    it("compares against the probed MCP port, not a hardcoded 3479", async () => {
+      writeEntry({ type: "http", url: "http://127.0.0.1:3479/mcp" });
+
+      const results = await userMcpAll({ mcpPort: 4918 });
+      const warn = results.find((x) => x.status === "warn");
+      expect(warn?.message).toContain("4918");
+    });
+
+    it("treats a port-less url as a mismatch and reports (none)", async () => {
+      writeEntry({ type: "http", url: "http://127.0.0.1/mcp" });
+
+      const warn = await userMcpResult();
+      expect(warn?.message).toContain("(none)");
+      expect(warn?.message).toContain("3479");
+      expect(warn?.fix).not.toMatch(/setup --apply/);
+    });
   });
 });
 

--- a/tests/cli/run-setup-apply.test.ts
+++ b/tests/cli/run-setup-apply.test.ts
@@ -1,3 +1,6 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 // `runSetup({ apply: true })` orchestrates the non-interactive write path
@@ -64,9 +67,18 @@ const CLAUDE_DESKTOP: DetectedTarget = {
 
 describe("runSetup({ apply: true }) orchestration", () => {
   let errSpy: ReturnType<typeof vi.spyOn>;
+  let home: string;
   const stderr = () => errSpy.mock.calls.map((c: unknown[]) => String(c[0] ?? "")).join("\n");
 
   beforeEach(() => {
+    // REQUIRED, not optional (#1811): this file mocks only apply.js, so
+    // `detectEnabledTandemPluginKey` would otherwise read the operator's real
+    // ~/.claude/settings.json in every --apply spec here and the negative spec
+    // would pass or fail by machine. Both env vars — `homedir()` reads
+    // USERPROFILE on Windows.
+    home = mkdtempSync(join(tmpdir(), "tandem-setup-apply-"));
+    vi.stubEnv("HOME", home);
+    vi.stubEnv("USERPROFILE", home);
     errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
     vi.mocked(detectTargets).mockReset();
     vi.mocked(applyConfig).mockReset();
@@ -76,7 +88,15 @@ describe("runSetup({ apply: true }) orchestration", () => {
   afterEach(() => {
     errSpy.mockRestore();
     vi.restoreAllMocks();
+    vi.unstubAllEnvs();
+    rmSync(home, { recursive: true, force: true });
   });
+
+  /** Write `~/.claude/settings.json` into the scratch home. */
+  const writeEnabledPlugins = (enabledPlugins: Record<string, unknown>) => {
+    mkdirSync(join(home, ".claude"), { recursive: true });
+    writeFileSync(join(home, ".claude", "settings.json"), JSON.stringify({ enabledPlugins }));
+  };
 
   it("writes config for a detected target and reports success (no exit)", async () => {
     vi.mocked(detectTargets).mockReturnValue([CLAUDE_CODE]);
@@ -250,6 +270,55 @@ describe("runSetup({ apply: true }) orchestration", () => {
 
     expect(applyConfig).toHaveBeenCalledTimes(1);
     expect(applyConfig).toHaveBeenCalledWith(CLAUDE_CODE.configPath, expect.anything());
+  });
+
+  // #1811 — `setup --apply` is the command that CREATES the duplicated
+  // tandem_* toolset, and it was the one surface that never mentioned it.
+  describe("plugin duplication notice", () => {
+    const noExit = () =>
+      vi.spyOn(process, "exit").mockImplementation((() => {
+        throw new Error("process.exit called");
+      }) as never);
+
+    it("warns when the plugin is installed, and still writes the config", async () => {
+      writeEnabledPlugins({ "tandem@tandem-editor": true });
+      vi.mocked(detectTargets).mockReturnValue([CLAUDE_CODE]);
+      vi.mocked(applyConfig).mockResolvedValue(undefined);
+      noExit();
+
+      await runSetup({ apply: true });
+
+      expect(stderr()).toContain("plugin uninstall tandem@tandem-editor");
+      // The discriminating half: warn, do not skip. `--apply`'s contract is
+      // "write the config", and skipping would strand a user who later
+      // disables the plugin with no output saying why.
+      expect(applyConfig).toHaveBeenCalledTimes(1);
+    });
+
+    it("says nothing when no settings file exists", async () => {
+      vi.mocked(detectTargets).mockReturnValue([CLAUDE_CODE]);
+      vi.mocked(applyConfig).mockResolvedValue(undefined);
+      noExit();
+
+      await runSetup({ apply: true });
+
+      expect(stderr()).not.toContain("plugin uninstall");
+    });
+
+    it("says nothing on a Claude Desktop-only run", async () => {
+      // The plugin is a Claude Code plugin: a desktop-only --apply writes no
+      // Claude Code entry and duplicates nothing, so the notice there would be
+      // a false statement prescribing the uninstall of a working plugin.
+      writeEnabledPlugins({ "tandem@tandem-editor": true });
+      vi.mocked(detectTargets).mockReturnValue([CLAUDE_CODE, CLAUDE_DESKTOP]);
+      vi.mocked(applyConfig).mockResolvedValue(undefined);
+      noExit();
+
+      await runSetup({ apply: true, targets: ["claude-desktop"] });
+
+      expect(stderr()).not.toContain("plugin uninstall");
+      expect(applyConfig).toHaveBeenCalledTimes(1);
+    });
   });
 
   /**

--- a/tests/cli/run-setup-apply.test.ts
+++ b/tests/cli/run-setup-apply.test.ts
@@ -82,7 +82,7 @@ describe("runSetup({ apply: true }) orchestration", () => {
     errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
     vi.mocked(detectTargets).mockReset();
     vi.mocked(applyConfig).mockReset();
-    vi.mocked(installSkill).mockReset().mockResolvedValue(undefined);
+    vi.mocked(installSkill).mockReset().mockResolvedValue({ written: true });
     vi.mocked(resolveChannelShimIntent).mockReset().mockResolvedValue(false);
   });
   afterEach(() => {
@@ -270,6 +270,30 @@ describe("runSetup({ apply: true }) orchestration", () => {
 
     expect(applyConfig).toHaveBeenCalledTimes(1);
     expect(applyConfig).toHaveBeenCalledWith(CLAUDE_CODE.configPath, expect.anything());
+  });
+
+  it("prints the kept-skill line when installSkill declined to downgrade (#1790)", async () => {
+    vi.mocked(detectTargets).mockReturnValue([CLAUDE_CODE]);
+    vi.mocked(applyConfig).mockResolvedValue(undefined);
+    vi.mocked(installSkill).mockResolvedValue({
+      written: false,
+      onDiskVersion: 999,
+      bundledVersion: 15,
+    });
+    vi.spyOn(process, "exit").mockImplementation((() => {
+      throw new Error("process.exit called");
+    }) as never);
+
+    await runSetup({ apply: true });
+
+    const out = stderr();
+    // Kills a caller that dereferences the result unguarded, and pins the
+    // remedy: DELETE the file. No Tandem version moves a `version: 999` file,
+    // so "upgrade Tandem" would be a dead-end fix line.
+    expect(out).toContain("kept the installed skill");
+    expect(out).toContain("v999");
+    expect(out).toContain("delete ~/.claude/skills/tandem/SKILL.md");
+    expect(out).not.toContain("✓ ~/.claude/skills/tandem/SKILL.md");
   });
 
   // #1811 — `setup --apply` is the command that CREATES the duplicated

--- a/tests/cli/setup.test.ts
+++ b/tests/cli/setup.test.ts
@@ -3,6 +3,7 @@ import { tmpdir } from "node:os";
 import { dirname, isAbsolute, join, resolve } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { runSetup } from "../../src/cli/setup.js";
+import { SKILL_CONTENT } from "../../src/cli/skill-content.js";
 // These helpers moved to src/server/integrations/apply.ts in #477 PR 3c-ii-a;
 // the back-compat re-export from src/cli/setup.ts was dropped in PR 3c-ii-c.
 import {
@@ -997,6 +998,92 @@ describe("installSkill", () => {
     const frontmatter = parts[1];
     expect(frontmatter).toContain("name: tandem");
     expect(frontmatter).toContain("description:");
+  });
+
+  // #1790 — `installSkill` was a bare write with no comparison, so an OLDER
+  // npm `tandem setup --apply` (which doctor prescribes for several
+  // conditions) silently downgraded a newer installed skill.
+  //
+  // The bundled number is derived from the exported SKILL_CONTENT with the
+  // four-line reader `refresh-skill.test.ts` already uses, rather than
+  // exporting `readSkillVersion` from apply.ts for a test.
+  const bundledVersion = (() => {
+    const match = SKILL_CONTENT.match(/^version:\s*(\d+)\s*$/m);
+    if (!match) return 0;
+    const n = parseInt(match[1], 10);
+    return Number.isFinite(n) ? n : 0;
+  })();
+
+  const writeSkill = (body: string): string => {
+    const skillPath = join(tmpDir, ".claude", "skills", "tandem", "SKILL.md");
+    mkdirSync(dirname(skillPath), { recursive: true });
+    writeFileSync(skillPath, body);
+    return skillPath;
+  };
+
+  it("keeps a NEWER installed skill and reports why", async () => {
+    const stub = [
+      "---",
+      "name: tandem",
+      "version: 999",
+      "description: newer",
+      "---",
+      "",
+      "newer body",
+      "",
+    ].join("\n");
+    const skillPath = writeSkill(stub);
+
+    const result = await installSkill({ homeOverride: tmpDir });
+
+    // Assert the BYTES, not just the return value — a fix that computes the
+    // verdict and writes anyway still fails here.
+    expect(readFileSync(skillPath, "utf-8")).toBe(stub);
+    expect(result).toEqual({ written: false, onDiskVersion: 999, bundledVersion });
+  });
+
+  it("overwrites an OLDER installed skill", async () => {
+    const skillPath = writeSkill(
+      ["---", "name: tandem", "version: 1", "description: old", "---", "", "old", ""].join("\n"),
+    );
+
+    const result = await installSkill({ homeOverride: tmpDir });
+
+    expect(readFileSync(skillPath, "utf-8")).toBe(SKILL_CONTENT);
+    expect(result).toEqual({ written: true });
+  });
+
+  it("REWRITES at the same version — the `>` boundary, and the repair path", async () => {
+    // The refresher's `>=` belongs to the silent background path. Here, equal
+    // is what almost every run is: `>=` would tell a current user that v15 is
+    // newer than v15, and would remove the repair path for a hand-mangled
+    // SKILL.md that still carries the current version.
+    const skillPath = writeSkill(
+      [
+        "---",
+        "name: tandem",
+        `version: ${bundledVersion}`,
+        "description: mangled",
+        "---",
+        "",
+        "mangled body",
+        "",
+      ].join("\n"),
+    );
+
+    const result = await installSkill({ homeOverride: tmpDir });
+
+    expect(readFileSync(skillPath, "utf-8")).toBe(SKILL_CONTENT);
+    expect(result).toEqual({ written: true });
+  });
+
+  it("writes when no file exists — the CREATE path", async () => {
+    // Kills copying the refresher's ENOENT early return into this path.
+    const result = await installSkill({ homeOverride: tmpDir });
+
+    const skillPath = join(tmpDir, ".claude", "skills", "tandem", "SKILL.md");
+    expect(readFileSync(skillPath, "utf-8")).toBe(SKILL_CONTENT);
+    expect(result).toEqual({ written: true });
   });
 
   it("includes key workflow guidance in the skill body", async () => {

--- a/tests/server/integrations/api-routes.test.ts
+++ b/tests/server/integrations/api-routes.test.ts
@@ -17,7 +17,10 @@ import {
   type IntegrationsRoutesDeps,
   registerIntegrationsRoutes,
 } from "../../../src/server/integrations/api-routes.js";
-import { MAX_CONFIG_BYTES } from "../../../src/server/integrations/apply.js";
+import {
+  MAX_CONFIG_BYTES,
+  type SkillInstallResult,
+} from "../../../src/server/integrations/apply.js";
 import type { ExistingMcpInstall } from "../../../src/server/integrations/existing-config.js";
 import {
   ClaudeInstallError,
@@ -160,12 +163,12 @@ describe("integrations API routes", () => {
   // route deliberately accepts no `homeOverride`, so every app built from
   // `deps` gets this spy. Without it the apply tests below rewrote the
   // operator's `~/.claude/skills/tandem/SKILL.md` on every run.
-  let installSkillSpy: ReturnType<typeof vi.fn<() => Promise<void>>>;
+  let installSkillSpy: ReturnType<typeof vi.fn<() => Promise<SkillInstallResult>>>;
 
   beforeEach(async () => {
     tmpDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), "tandem-int-api-"));
     backend = memoryBackend();
-    installSkillSpy = vi.fn(async () => {});
+    installSkillSpy = vi.fn(async (): Promise<SkillInstallResult> => ({ written: true }));
     deps = {
       installSkill: installSkillSpy,
       store: createIntegrationsStore(tmpDir),

--- a/tests/server/integrations/api-routes.test.ts
+++ b/tests/server/integrations/api-routes.test.ts
@@ -18,6 +18,8 @@ import {
   registerIntegrationsRoutes,
 } from "../../../src/server/integrations/api-routes.js";
 import {
+  _resetSkillRefreshErrorForTests,
+  getSkillRefreshError,
   MAX_CONFIG_BYTES,
   type SkillInstallResult,
 } from "../../../src/server/integrations/apply.js";
@@ -186,6 +188,7 @@ describe("integrations API routes", () => {
   });
 
   afterEach(async () => {
+    _resetSkillRefreshErrorForTests();
     if (tmpDir) await fs.promises.rm(tmpDir, { recursive: true, force: true });
   });
 
@@ -1170,6 +1173,93 @@ describe("integrations API routes", () => {
         expect(after.mcpServers.tandem).toBeDefined();
         // The nonce rotated because a write occurred.
         expect(body.nextNonce).not.toBe(nonce);
+      });
+
+      // Post-ship review of #1790. `installSkill()` declines to downgrade a
+      // NEWER skill on disk, and the route used to discard that result: 200,
+      // every integration `applied`, and nothing anywhere said the skill was
+      // left alone — `getSkillRefreshError()` stayed null because only the
+      // refresher ever set it. The response shape is deliberately unchanged
+      // (a declined skill is not a failed integration); the decline rides the
+      // refresher's channel, which `/api/launcher/status` already surfaces.
+      describe("a declined skill install reaches the skill-refresh error channel", () => {
+        async function applyOnce(): Promise<{
+          status: number;
+          results: Array<{ status: string }>;
+        }> {
+          const tmpClaudeJson = path.join(tmpDir, ".claude.json");
+          fs.writeFileSync(tmpClaudeJson, JSON.stringify({ mcpServers: {} }));
+          await deps.store.write({
+            schemaVersion: INTEGRATIONS_SCHEMA_VERSION,
+            integrations: [
+              {
+                kind: "claude-code",
+                id: "cc-1",
+                label: "Claude Code",
+                configPath: tmpClaudeJson,
+                transport: "http",
+                url: "http://127.0.0.1:3479",
+              },
+            ],
+          });
+          const app = makeApp({
+            ...deps,
+            detectTargets: () => [
+              { label: "Claude Code", configPath: tmpClaudeJson, kind: "claude-code" },
+            ],
+            shouldRegisterChannelShim: () => false,
+          });
+          const nonce = await freshNonce(app);
+          const res = await request(
+            app,
+            "POST",
+            API_INTEGRATIONS_APPLY,
+            { ids: ["cc-1"], confirmationNonce: nonce },
+            TAURI_ORIGIN,
+          );
+          return {
+            status: res.status,
+            results: (res.body as { results: Array<{ status: string }> }).results,
+          };
+        }
+
+        it("records newer-on-disk without changing the apply response", async () => {
+          installSkillSpy.mockResolvedValueOnce({
+            written: false,
+            onDiskVersion: 16,
+            bundledVersion: 15,
+          });
+          const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+          try {
+            const { status, results } = await applyOnce();
+            expect(status).toBe(200);
+            expect(results[0]?.status).toBe("applied");
+            expect(installSkillSpy).toHaveBeenCalledTimes(1);
+            expect(getSkillRefreshError()).toEqual({
+              code: "newer-on-disk",
+              message: expect.stringMatching(/v16.*v15.*SKILL\.md/),
+            });
+            expect(errorSpy).toHaveBeenCalledWith(
+              expect.stringContaining("kept the installed skill"),
+            );
+          } finally {
+            errorSpy.mockRestore();
+          }
+        });
+
+        it("a written install clears a prior record, as the refresher's success does", async () => {
+          installSkillSpy.mockResolvedValueOnce({
+            written: false,
+            onDiskVersion: 16,
+            bundledVersion: 15,
+          });
+          await applyOnce();
+          expect(getSkillRefreshError()?.code).toBe("newer-on-disk");
+
+          // Default spy: `{ written: true }`.
+          await applyOnce();
+          expect(getSkillRefreshError()).toBeNull();
+        });
       });
 
       it("create-wins: keeps tandem-channel even when listed in removals if the shim is being registered (#985)", async () => {

--- a/tests/server/mcp-stdio-ports.test.ts
+++ b/tests/server/mcp-stdio-ports.test.ts
@@ -1,0 +1,59 @@
+/**
+ * `startMcpServerStdio` threads the live ports into `tandem_diagnostics`.
+ *
+ * #1806 made the CLI doctor and the HTTP embedders probe the ports the server
+ * actually binds (`TANDEM_PORT` / `TANDEM_MCP_PORT`), but the stdio path still
+ * built its server with no ports at all, so `tandem_diagnostics` over stdio on
+ * a moved install probed 3478/3479, reported them not listening and prescribed
+ * a second instance. `index.ts` resolves the ports once; this pins that the
+ * stdio entry carries them the whole way to the collector.
+ *
+ * `runDoctor` is mocked at the module boundary: the real collector reads the
+ * caller's HOME and walks PATH, and neither belongs in a wiring test.
+ */
+
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { runDoctor } from "../../src/cli/doctor.js";
+import { startMcpServerStdio } from "../../src/server/mcp/server.js";
+
+vi.mock("../../src/cli/doctor.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../src/cli/doctor.js")>();
+  const stub: import("../../src/cli/doctor.js").DoctorReport = {
+    ok: true,
+    crashed: false,
+    failures: 0,
+    warnings: 0,
+    summary: "All checks passed.",
+    error: null,
+    results: [{ check: "health", status: "pass", message: "stubbed" }],
+  };
+  return { ...actual, runDoctor: vi.fn(async () => stub) };
+});
+
+describe("startMcpServerStdio port threading", () => {
+  let client: Client | null = null;
+
+  afterEach(async () => {
+    await client?.close();
+    client = null;
+    vi.mocked(runDoctor).mockClear();
+  });
+
+  it("hands the resolved ports to tandem_diagnostics, not the defaults", async () => {
+    const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+    await startMcpServerStdio({ wsPort: 1234, mcpPort: 5678 }, serverTransport);
+    client = new Client({ name: "test-client", version: "0.0.1" });
+    await client.connect(clientTransport);
+
+    const result = (await client.callTool({ name: "tandem_diagnostics", arguments: {} })) as {
+      structuredContent?: { transport?: string };
+    };
+
+    // Exactly-once with exactly these: a fix that threads only one of the two
+    // `??` reads, or none, lands on 3478/3479 here and fails.
+    expect(vi.mocked(runDoctor)).toHaveBeenCalledExactlyOnceWith({ wsPort: 1234, mcpPort: 5678 });
+    expect(result.structuredContent?.transport).toBe("stdio");
+  });
+});

--- a/tests/skill-instruction-contract.test.ts
+++ b/tests/skill-instruction-contract.test.ts
@@ -1,3 +1,4 @@
+import { createHash } from "node:crypto";
 import { readFileSync } from "node:fs";
 import { describe, expect, it } from "vitest";
 
@@ -304,6 +305,32 @@ describe("shipped Tandem skill instruction contract", () => {
 
     expect(section).toMatch(/orchestrator/i);
     expect(section).toContain("tandem_checkInbox");
+  });
+
+  // #1790 item 3. Until now this file pinned the frontmatter `version:` NUMBER only, so a
+  // content-only edit at an unchanged version was invisible — the miss that made v0.20.0 and
+  // v0.20.1 never reach upgraders, since the refresh gate is version-keyed.
+  //
+  // The hash covers the text AFTER the frontmatter's closing `---`, with CRLF normalised
+  // first (this repo's CRLF-staleness hazard must not red the suite). Excluding the
+  // frontmatter is deliberate: a version bump alone does not churn the hash, so the loud case
+  // is exactly "body changed, version did not".
+  //
+  // HONEST LIMIT: this forces a deliberate edit at the spot that says what to do. It cannot
+  // prove the bump happened.
+  it("reds on a body-only skill edit, not just a version change (#1790)", () => {
+    const skill = readShippedSkill().replace(/\r\n/g, "\n");
+    const frontmatterBlock = /^---\n[\s\S]*?\n---\n/.exec(skill)?.[0];
+    expect(frontmatterBlock, "the shipped skill has no frontmatter").toBeDefined();
+    const body = skill.slice((frontmatterBlock ?? "").length);
+    const bodyHash = createHash("sha256").update(body, "utf8").digest("hex").slice(0, 12);
+
+    expect(
+      { version: /^version:\s*(\d+)\s*$/m.exec(skill)?.[1], bodyHash },
+      "skills/tandem/SKILL.md changed. Bump its frontmatter `version:` AND update BOTH " +
+        "literals here in the same commit — the installed copy only refreshes when the " +
+        "bundled version is newer, so a body edit at an unchanged version never ships.",
+    ).toEqual({ version: "15", bodyHash: "cfd1176de0cf" });
   });
 
   it("tells Claude not to insert mid-paragraph line breaks (#1737)", () => {


### PR DESCRIPTION
## Summary

**#1806 — `tandem doctor` ignores the port env vars.** `runDoctorCli` never read `TANDEM_PORT` / `TANDEM_MCP_PORT`, so on an install deliberately moved off 3478/3479 doctor probed the defaults, found nothing, reported the server as "not running" and prescribed starting a second instance on top of a healthy one. The CLI wrapper now resolves both env vars and threads them into `runDoctor`. `runDoctor` itself keeps its documented no-environment contract — `/api/diagnostics` already threads live ports — so the resolution happens in `runDoctorCli` only.

**#1807 — the user-level `~/.claude.json` entry passed on key presence alone.** Doctor's project-level `.mcp.json` check validates `type` and `url`; its user-level twin only asked whether a `tandem` key existed, so an entry naming the wrong port, the wrong transport type, or a url without `/mcp` read green while Claude Code could not connect. The user-level entry is now validated the same way — transport type, loopback host, an `http:` scheme (`https` is REJECTED — the MCP server is plaintext HTTP on loopback, so a TLS url is green in the file Claude Code consults while Claude Code cannot connect), an `/mcp` path, and the port doctor actually resolved and probed. The port arm carries a non-dead-end fix line naming both remedies (edit the url, or unset `TANDEM_MCP_PORT`).

**#1811 — the plugin plus `tandem setup --apply` loads the `tandem_*` toolset twice.** Doctor documented the duplication as known with no remedy, and `setup --apply` said nothing at all. Doctor now detects both installs (an `enabledPlugins` entry in `~/.claude/settings.json` with `value === true` matching any `tandem@<marketplace>` key, alongside a `tandem` MCP entry) and names the remedy. `setup --apply` warns before it writes when the plugin is installed, and still writes — its contract is to write, and the warning tells the user which of the two to keep.

**#1790 — `installSkill` overwrote the installed skill without comparing versions.** A newer `SKILL.md` on disk was silently replaced by an older bundled one, the reverse of `refreshExistingSkillIfStale`'s behaviour. `installSkill` now compares versions and keeps the newer on-disk copy, printing what it kept and how to force the replacement. It still writes when the bundled skill carries no version stamp and when the on-disk read fails for any reason other than `ENOENT` — it is the consent-bearing installer. The skill content test now hashes the body below the frontmatter (CRLF-normalised) rather than only the version number, so a content-only edit cannot ship un-bumped. Item 2 of the issue — the plugin manifest lagging `package.json` — needed no code: `plugin.json` is already in sync, the release skill already enumerates all five version surfaces, and `tests/plugin-manifest.test.ts` plus `tests/plugin/plugin-version-pin.test.ts` already pin them; the spec measured that rather than re-fixing it.

The `#1894` injected `installSkill` seam on `IntegrationsRoutesDeps` is preserved, and every new test runs against a scratch HOME.

## Closes

Closes #1806
Closes #1807
Closes #1811
Closes #1790

## Verification

`.husky/pre-push` ran in full on this branch: biome, `typecheck:tests`, the whole vitest suite, and `cargo test` (216/216, including the three doc-tests) — all green, no `--no-verify`.

```
TESTS: Test Files 5 passed (5) / Tests 393 passed (393)
```

Manual probes:

```
#1806 — doctor honours the port env vars
  WITH TANDEM_PORT=4928 TANDEM_MCP_PORT=4929 (server running on that pair):
    [PASS] Ports 4928 (WebSocket) + 4929 (MCP HTTP) in use
    [PASS] Server healthy (v0.25.0, http, no MCP session)
  WITHOUT the env vars (same running server), the old symptom persists as expected:
    [FAIL] Ports 3478 + 3479 not listening — server not running

#1807 — user-level ~/.claude.json entry is now validated
  scratch HOME, {"tandem":{"type":"http","url":"http://127.0.0.1:3479/"}} (no /mcp):
    [WARN] ~/.claude.json tandem: unexpected config — type=http, pathHasMcp=false
  scratch HOME, {"tandem":{"type":"stdio","url":"http://127.0.0.1:3479/mcp"}}:
    [WARN] ~/.claude.json tandem: unexpected config — type=stdio, pathHasMcp=true
  real HOME under TANDEM_MCP_PORT=4929 (port-mismatch arm, with its non-dead-end fix):
    [WARN] ~/.claude.json tandem: url names port 3479, but Tandem's MCP port is 4929
           Fix: Edit the tandem entry's url in ~/.claude.json to use port 4929, or unset TANDEM_MCP_PORT and restart Tandem.

#1811 — both halves
  doctor (scratch HOME with enabledPlugins {"tandem@tandem-editor":true} + a tandem entry):
    [WARN] Both the Tandem plugin and a tandem MCP entry in ~/.claude.json are present — the tandem_* tools will appear twice
           Fix: ... `claude plugin uninstall tandem@tandem-editor` leaves the Tandem-managed config in place.
  setup --apply (the newly-added half), printed before the write:
    ⚠ The Tandem plugin (tandem@tandem-editor) is installed and already provides the tandem_* tools.
      Writing this config too makes every tool appear twice — keep one:
      claude plugin uninstall tandem@tandem-editor

#1790 — installSkill no longer downgrades
  scratch ~/.claude/skills/tandem/SKILL.md stamped `version: 999`, then setup --apply:
    ⚠ kept the installed skill (v999 on disk is newer than this install's v15) — delete ~/.claude/skills/tandem/SKILL.md and re-run to replace it
  scratch file after the run still reads `version: 999` / "MINE DO NOT OVERWRITE".
  Real ~/.claude/skills/tandem/SKILL.md md5 unchanged across the run (90400dd9… before and after) — the #1894 seam held.
```

Environment artifact, not a regression: under the scratch HOME the MCP write itself failed with
`Refusing path outside allowed roots: realpath=C:\Users\blokn\AppData\Local\tandem\Data\.backups`
— `maybeBackupExistingConfig`'s `allowedRoots` is keyed off the real app-data dir, pre-existing on master
and unrelated to this diff. The plugin notice and the skill path both still executed.

Cleanup: scratch server killed (0 listeners on 4928/4929); temp driver removed; `git status --porcelain` clean in the worktree.

No E2E and no client change (`e2e=false`), and no visible UI change, so no screenshots.

## Review

Plan review rounds: 4. PR review rounds: 3.

Unresolved findings: none. The scheme check the third round asked for landed in `78d368c5` (`parsed.protocol !== "http:"`).

### Follow-up pass (after the workflow returned)

Three post-ship findings had not reached the fix loop; each was skeptic-checked on the branch and fixed with a mutation check (key line reverted, pinned test red, restored):

| Finding | Outcome |
|---|---|
| `doctor.ts` non-loopback-host arm said "Tandem's MCP server is loopback-only" and prescribed rewriting the url to `127.0.0.1` — false under `TANDEM_BIND_HOST`, which puts the resolved LAN IP into the SDK's `allowedHosts` | `14516889`: still a warn, but the sentence now says it listens on loopback unless started with `TANDEM_BIND_HOST`, and the fix is conditioned on that. Doctor runs in the user's shell and cannot know the server's bind host, so it stops asserting. No url interpolated. |
| Apply route discarded the new `SkillInstallResult`, so the wizard reported success while a newer on-disk skill was declined and `getSkillRefreshError()` stayed null (the round-4 refutation said "no regression"; it is one relative to the CLI half, which now prints the notice, and the wizard is the documented first-run path) | `9c6edbf6`: `recordSkillInstallOutcome` in `apply.ts` records `newer-on-disk` through the same channel the refresher uses (the client already renders it) and clears on a write; one `console.error` line; response shape unchanged. Two specs via the `installSkill` seam. |
| `startMcpServerStdio` built the MCP server with no ports, so `tandem_diagnostics` in stdio mode with moved ports reported the defaults as not listening — the #1806 symptom on the surface an AI client self-diagnoses with | `6c1d709d`: `index.ts` passes the ports it already resolves; the transport parameter is the seam for a new `mcp-stdio-ports.test.ts` that drives `tandem_diagnostics` over `InMemoryTransport`. |

Known limit: the client prefixes every `skillRefresh` message with "Run `tandem setup` to retry", which for `newer-on-disk` is slightly off (setup declines too); the message body carries the right delete-the-file remedy, and the client was out of scope.

## Assumptions

- #1807's new outcomes are `warn`, never `fail`, for parity with the existing `.mcp.json` twin and so `tandem doctor` does not start exiting 1 on a machine whose tools arrive via the plugin. The wave note's "must read red" is read as "must not read green".
- #1807 compares against the port doctor resolved and probed (after #1806), not against a reachability handshake — same answer, no check reordering, and it still works when the server is down.
- #1806 resolves the env in `runDoctorCli` only; `runDoctor` keeps its documented no-environment contract because `/api/diagnostics` already threads live ports.
- #1811: `setup --apply` WARNS and still writes the MCP entry rather than skipping it. The issue suggests skipping; the track file's taken shape says warn, and `--apply`'s contract is to write.
- #1811: an installed plugin is detected from `enabledPlugins` in `~/.claude/settings.json` with `value === true`, matching any `tandem@<marketplace>` key — the predicate doctor already uses.
- #1790: `installSkill` still writes when the bundled skill has no version stamp (`BUNDLED_SKILL_VERSION === 0`) and when the on-disk read fails for any reason other than `ENOENT` — it is the consent-bearing installer, unlike `refreshExistingSkillIfStale`.
- #1790: the pinned content hash covers the body BELOW the frontmatter (CRLF-normalised), so a version-only bump does not churn it.
- #1790 item 2 needs no code: `plugin.json` is in sync with `package.json`, the release skill already enumerates all five values, and `tests/plugin-manifest.test.ts` plus `tests/plugin/plugin-version-pin.test.ts` already pin them.

## For Bryan

- `tandem doctor` still has no `MAX_CONFIG_BYTES` cap on its `~/.claude.json` read while `setup --apply` refuses at 16 MiB (the For-Bryan item from #1891). It does not fall out of #1807's validation — doctor reads through `readClaudeConfig`, a different reader from `readConfigForMutation` — so per the wave note it was left alone. Decide whether to file it.
- #1790's residual exposure is not repairable from the repo: a user's INSTALLED plugin keeps pinning the version it was installed at (e.g. `tandem-editor@0.24.1`) against a newer server until they reinstall it. The repo-side guards are already complete. Options: (a) accept and document, (b) add a doctor check that reads the installed plugin manifest and warns on pin drift — a new surface this group deliberately did not build.
- #1807's warn-vs-fail choice: confirm that a wrong `type` or a URL without `/mcp` in `~/.claude.json` should warn (exit 0) rather than fail (exit 1). The spec chose warn for parity with the `.mcp.json` twin.
- `apply.ts:186`'s `MCP_URL` is hardcoded to `DEFAULT_MCP_PORT`, so `setup --apply` writes a `:3479` entry even on a `TANDEM_MCP_PORT`-moved install. #1807 will now report it; nobody has filed the writer-side defect. Say whether to file it or fold it into a later F group. Fixing it is a design call, not a mechanical edit: `MCP_URL` also feeds the desktop stdio entry's `TANDEM_URL` (`:502`) and the shim's (`:518`), and the setup shell's environment need not be the server's — which makes the new port warn UNCLEARABLE on a deliberately moved install.
- #1811: the `<home>/.claude/settings.json` derivation is now spelled out twice in `src/cli/doctor.ts` plus a `SETTINGS_LEAF` literal in `tests/cli/doctor-path-safety.test.ts:127,261`. The consolidation is `claudeCodeSettingsPath()` in `src/shared/integrations/client-config-paths.ts` with both callers repointed — a refactor of a UNC-screened doctor path, above this group's bar.
- #1790: the wizard route cannot repair a `SKILL.md` stamped `version: 999`. Deleting the file and re-running is the remedy, and `setup --apply` is now the only surface that says so — the `/api/integrations/apply` route still echoes nothing about the skill.

## Post-ship review (round 4)

One confirmed finding, fixed in `158c0fa6`: the three `address review` commits changed
`validateUserTandemEntry` and none updated `docs/reviews/2026-09-02-v1-review/tracks/specs/F-doctor-1807.md`,
so the tracked spec described a fix that is no longer the one shipped — it omitted the
non-loopback-host arm and the scheme half of arm 2, and asserted "`type` stays verbatim
(enum-shaped)" against code that clamps it. The Tauri-host entry is why that matters: the arm was
introduced by a well-meant fix and then had to be taken back out, and a planner reading the stale
spec would have reintroduced it. The spec now carries a "Review corrections (rounds 2-3)" section.
`F-doctor-1790.md`'s `result?.written` reference was corrected to the `!result.written` that
`/simplify` left. Also corrected above: this body previously claimed the validator accepts
"`http`/`https`"; `https` is rejected.

Refuted: the `/api/integrations/apply` route ignoring the new `SkillInstallResult` (it reported
nothing about the skill before this PR either, so no regression); `checkMcpJson`'s hardcoded
`3479` in the `tandem-channel` `TANDEM_URL` fix line (pre-existing, unchanged lines, outside the
minimal scope); an entry with a valid url but no `type` key now warning (deliberate, tested,
warn-only, and `setup --apply` clears it). Mutation-tested the two load-bearing boundaries:
`>` → `>=` in `installSkill` and disabling the loopback-host arm each red a test.


🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019z7FSDdV1rUQKy1xEMncYQ


