### PR TITLE
fix: four pieces of code that describe themselves wrongly (#1821 residue)

### DIFF
--- a/docs/mcp-tools.md
+++ b/docs/mcp-tools.md
@@ -73,9 +73,9 @@ For these tools, `structuredContent` carries the exact same object as the text e
 | `ANNOTATION_RESOLVED` | The same condition under a different name, from `tandem_editAnnotation` and `tandem_annotationReply`. The two codes are not interchangeable -- match on the tool you called. |
 | `ACCEPT_REFUSED` | `tandem_resolveAnnotation({ action: "accept" })` on Claude's own annotation, or on one carrying `suggestedText`. Accept is the user's decision; `dismiss` withdraws instead (#1770). |
 | `SEARCH_BUSY` | `tandem_search` with `regex: true` was called while its worker queue -- one search running plus three waiting -- was already full. Retry. |
-| `INTERNAL_ERROR` | The universal boundary code: a handler threw something no arm translated and `withErrorBoundary` flattened it (`src/server/mcp/response.ts:118`). The message reads `<toolName> failed: ...`. Any tool can return it. |
+| `INTERNAL_ERROR` | The universal boundary code: a handler threw something no arm translated and `withErrorBoundary` flattened it (`src/server/mcp/response.ts:118`). The message reads `<toolName> failed: ...`. Any tool can return it. It is also the `never`-exhaustiveness arm on `tandem_resolveAnnotation` and `tandem_removeAnnotation`, reachable only if a lifecycle outcome is added without being handled -- which is a compile error first, so that message should never be seen. |
 
-Two more codes exist in source and should never be seen. `INTERNAL` -- note the missing `_ERROR` -- is the `never`-exhaustiveness arm on `tandem_resolveAnnotation` and `tandem_removeAnnotation` (`src/server/mcp/annotations.ts:520`, `:566`), reachable only if a lifecycle outcome is added without being handled, which is a compile error first. And `tandem_rename` passes five refusals through from `renameDocument` verbatim -- `NOT_RENAMABLE`, `EXTENSION_MISMATCH`, `ALREADY_EXISTS`, `RENAME_IN_PROGRESS`, `PATH_REJECTED` -- listed under that tool rather than here, because nothing else emits them.
+`INTERNAL` -- note the missing `_ERROR` -- is a **different** code and is **not** an MCP one: it belongs to the `/api` surface (`src/server/mcp/routes/_shared.ts`), which has its own code vocabulary. The two annotation exhaustiveness arms carried it by accident until they were corrected; no MCP tool emits it. And `tandem_rename` passes five refusals through from `renameDocument` verbatim -- `NOT_RENAMABLE`, `EXTENSION_MISMATCH`, `ALREADY_EXISTS`, `RENAME_IN_PROGRESS`, `PATH_REJECTED` -- listed under that tool rather than here, because nothing else emits them.
 
 ## Coordinate System
 
@@ -1055,7 +1055,8 @@ Check if the user is actively editing and where their cursor is.
 - `active` is true if `isTyping`, or the user typed within the last 10 seconds (`src/server/mcp/awareness.ts:304`).
 - `isTyping` is true during active keystroke bursts; the client clears it `TYPING_DEBOUNCE` = 3000 ms after the last keystroke (`src/shared/constants.ts:179`).
 - `cursor` is a **ProseMirror position** (#1776) — see above. `null` when there is no activity.
-- The tool returns exactly these four fields. Despite what its registered description says, it returns **no** `selection` and **no** `documentId` (`src/server/mcp/awareness.ts:292`, `:306-311`) — the description is stale, not the handler.
+- The tool returns exactly these four fields: no `selection` and no `documentId`. For what the user has selected, read `tandem_checkInbox`'s `activity.selectedText`, which *is* in flat offsets. (Until the registered description was corrected it promised both; the handler never returned either.)
+- The no-activity branch returns `active: false`, `isTyping: false`, `cursor: null`, `lastEdit: null` and a `message`. `isTyping` was absent there until it was added alongside the description fix, so an older server returns `undefined` for it on that branch.
 - Use this to avoid interrupting the user while they're typing.
 
 ---

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -103,12 +103,12 @@ if (!isStdioMode) {
 
 try {
   if (args[0] === "--uninstall-scrub") {
-    // Invoked by the Tauri NSIS uninstaller hook on Windows, and manually on
-    // any platform before removing the app. Removes Tandem's MCP config
-    // entries + bundled skill everywhere; Cowork plugin entries + firewall
-    // rules on Windows. Runs inside the already-signed tandem.exe rather than a
-    // separate uninstall_scrub.exe — a dedicated scrub binary would sit unsigned
-    // beside the installer at uninstall time, which is a binary-planting target.
+    // Run by hand on any platform before removing the app — nothing invokes it
+    // automatically. The Tauri NSIS uninstall hook runs the DESKTOP binary's
+    // --uninstall-scrub (src-tauri/src/uninstall_scrub.rs), which never reaches
+    // this file. Removes Tandem's MCP config entries + bundled skill
+    // everywhere; Cowork plugin entries + firewall rules on Windows. See the
+    // docblock in ./uninstall-scrub.ts for how the two scrubs divide.
     const { runUninstallScrub } = await import("./uninstall-scrub.js");
     const exitCode = await runUninstallScrub();
     process.exit(exitCode);

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -67,8 +67,11 @@ Usage:
   tandem activate <license|path>    Activate a signed license (string or file path)
   tandem license                    Show the current license / trial status
   tandem --uninstall-scrub          Remove Tandem's MCP entries, skill, and Cowork
-                                    registration from Claude configs (run before
-                                    uninstalling; the Windows uninstaller runs it)
+                                    registration from Claude configs. Run it
+                                    yourself before uninstalling — no uninstaller
+                                    runs it; the Windows one runs the desktop
+                                    app's own scrub, which leaves MCP entries and
+                                    the skill in place
   tandem mcp-stdio                  Run as a stdio MCP server proxying to local HTTP
                                     (used by the plugin's Cowork bridge; requires
                                     tandem server running on the host)

--- a/src/cli/uninstall-scrub.ts
+++ b/src/cli/uninstall-scrub.ts
@@ -1,10 +1,20 @@
 /**
  * Tandem `--uninstall-scrub` subcommand.
  *
- * Invoked by the Tauri NSIS installer hook during uninstall on Windows, and
- * manually invocable on every platform (run it *before* deleting the app /
- * `npm uninstall -g` — see docs/data-locations.md). Removes every reference
- * Tandem wrote into other programs' config:
+ * **Invoked by hand, on every platform** — run it *before* deleting the app /
+ * `npm uninstall -g` (see docs/data-locations.md). Nothing invokes it
+ * automatically: the Tauri NSIS uninstall hook runs
+ * `"$INSTDIR\${MAINBINARYNAME}.exe" --uninstall-scrub`, which is the DESKTOP
+ * binary and reaches the Rust `src-tauri/src/uninstall_scrub.rs`, not this
+ * file. **Neither scrub is a superset of the other**: the Rust one alone
+ * removes the start-at-login registration, and this one alone removes the MCP
+ * config entries and the bundled skill — which the desktop bundle cannot reach
+ * because the npm CLI is not among the Tauri `resources`. They overlap on the
+ * Cowork plugin entries and the Cowork firewall rules, both idempotent. So a
+ * Windows user who only uninstalls the desktop app keeps their
+ * `mcpServers.tandem` entries until they run this by hand.
+ *
+ * Removes every reference Tandem wrote into other programs' config:
  *   - Cowork workspaces (Windows): `installed_plugins.json`
  *     (`mcpServers.tandem`), `known_marketplaces.json`
  *     (`marketplaces.tandem`), `cowork_settings.json` (`tandem@tandem` in
@@ -20,16 +30,16 @@
  * keychain) — the scrub removes references to a binary about to disappear;
  * user data stays unless the user deletes it (docs/data-locations.md).
  *
- * **Runs inside the already-signed binary.** Invoked from `tandem.exe` itself —
- * NOT as a separate `uninstall_scrub.exe`. A dedicated scrub executable would be
- * an unsigned binary sitting beside the installer at uninstall time, which is a
- * binary-planting target.
+ * The signed-binary / binary-planting rationale belongs to the Rust scrub, not
+ * to this one: it is what stops the NSIS hook from shelling out to a separate
+ * `uninstall_scrub.exe` an attacker could plant. This subcommand is reached
+ * only by a user typing it, so it inherits whatever trust its `tandem` on PATH
+ * already has.
  *
  * **Failure policy:** logs every error, exits 0 on clean-or-not-installed,
- * non-zero only on unrecoverable I/O failures. NSIS logs the exit code but
- * does NOT block uninstall — Tandem must always uninstall even if a
- * workspace scrub partially fails. Each step is isolated: a failure in one
- * never skips the rest.
+ * non-zero only on unrecoverable I/O failures. Nothing consumes that exit code
+ * but the user's shell. Each step is isolated: a failure in one never skips
+ * the rest.
  *
  * **Token safety:** this scrub READS JSON to find Tandem entries but the
  * removed-entry contents (including the auth token) are NEVER logged, and

--- a/src/server/mcp/annotations.ts
+++ b/src/server/mcp/annotations.ts
@@ -516,8 +516,17 @@ export function registerAnnotationTools(server: McpServer): void {
         default: {
           // A new `LifecycleResult` arm errors HERE, naming it — the shape the
           // remove switch uses, for the same reason.
+          //
+          // `INTERNAL_ERROR`, not `INTERNAL`: the two are different strings on
+          // the wire, and MCP's own catch-all is `INTERNAL_ERROR`
+          // (`response.ts:118`). `INTERNAL` is the `/api` surface's code
+          // (`routes/_shared.ts`) and stays there — these two sites had it by
+          // accident, which gave the MCP surface two codes for one condition.
           const unhandled: never = result;
-          return mcpError("INTERNAL", `unhandled resolve outcome: ${JSON.stringify(unhandled)}`);
+          return mcpError(
+            "INTERNAL_ERROR",
+            `unhandled resolve outcome: ${JSON.stringify(unhandled)}`,
+          );
         }
       }
     }),
@@ -563,7 +572,10 @@ export function registerAnnotationTools(server: McpServer): void {
           // never mentions the arm or this switch, and whose obvious fix is a
           // generic `default` that swallows it.
           const unhandled: never = result;
-          return mcpError("INTERNAL", `unhandled remove outcome: ${JSON.stringify(unhandled)}`);
+          return mcpError(
+            "INTERNAL_ERROR",
+            `unhandled remove outcome: ${JSON.stringify(unhandled)}`,
+          );
         }
       }
     }),

--- a/src/server/mcp/awareness.ts
+++ b/src/server/mcp/awareness.ts
@@ -274,11 +274,15 @@ export function finalizeClaudeChatMessage(id: string): void {
 export function registerAwarenessTools(server: McpServer): void {
   server.tool(
     "tandem_getActivity",
-    "Report whether the user is currently typing (`isTyping`), where their cursor and selection " +
-      "are, and which document they are in. Call it before annotating or editing near the " +
-      "user's cursor — annotating text someone is mid-sentence on is disruptive, and the range " +
-      "is likely to move under you. Returns presence only; it does not return document content " +
-      "or pending user messages (use tandem_checkInbox for those).",
+    "Report whether the user is currently typing (`isTyping`) and where their cursor is, in " +
+      "the target document. Call it before annotating or editing near the user's cursor — " +
+      "annotating text someone is mid-sentence on is disruptive, and the range is likely to " +
+      "move under you. Returns four fields — `active`, `isTyping`, `cursor`, `lastEdit` — and " +
+      "no selection: use tandem_checkInbox's `activity.selectedText` for what the user has " +
+      "selected. " +
+      "`cursor` is a ProseMirror position, not a flat offset (#1776). Returns presence only; " +
+      "it does not return document content or pending user messages (use tandem_checkInbox " +
+      "for those).",
     {
       documentId: z
         .string()
@@ -292,8 +296,15 @@ export function registerAwarenessTools(server: McpServer): void {
       const { activity } = store.getUserAwareness();
 
       if (!activity) {
+        // `isTyping` is present on BOTH branches. The tool description names it
+        // as the headline field, and a caller reading `data.isTyping` on the
+        // no-activity branch used to get `undefined` — falsy, so the common
+        // `if (!isTyping)` read happened to work, and a `typeof` or a strict
+        // `=== false` check silently did not. Never seen: awareness is absent
+        // only before the first client write.
         return mcpSuccess({
           active: false,
+          isTyping: false,
           cursor: null,
           lastEdit: null,
           message: "No activity detected",

--- a/src/server/mcp/document.ts
+++ b/src/server/mcp/document.ts
@@ -465,7 +465,7 @@ export function registerDocumentTools(server: McpServer): void {
 
   server.tool(
     "tandem_open",
-    "Open a file in the Tandem editor; returns a documentId. Auto-opens the editor. force=true reloads from disk if the file changed externally.",
+    "Open a file in the Tandem editor as a new tab; returns a documentId. Does NOT launch or focus the editor — #477 removed browser auto-open, and nothing here reaches the desktop window's `show_main_window`; the user sees the tab when they next look at an editor that is already running. force=true reloads from disk if the file changed externally.",
     {
       filePath: z.string().describe("Absolute path to the file to open"),
       force: z

--- a/tests/server/mcp-tool-integration.test.ts
+++ b/tests/server/mcp-tool-integration.test.ts
@@ -1385,6 +1385,12 @@ describe("MCP tool integration — awareness tools", () => {
     expect(empty.error).toBe(false);
     expect(empty.data.active).toBe(false);
     expect(empty.data.cursor).toBe(null);
+    // `isTyping` is present on BOTH branches, and the assertion is `toBe(false)`
+    // rather than a falsy check on purpose: this branch used to omit the field
+    // entirely, which every `if (!isTyping)` read tolerated and every
+    // `=== false` / `typeof` read did not. A falsy assertion here would pass
+    // against the omission it exists to prevent.
+    expect(empty.data.isTyping).toBe(false);
 
     // **And the `documentId` argument must still route.** The handler was
     // repointed from a hand-rolled `getCurrentDoc(documentId)` +


### PR DESCRIPTION
Four defects the #1821 documentation sweep found in `src/` and could not
touch — every docs group's allowlist stopped at `docs/`, so each was
recorded in a PR body and then had no home. All four are code that
describes itself wrongly; two of them reach a user.

## `tandem_getActivity` promised two fields it has never returned

The registered description said the tool reports "where their cursor
**and selection** are, and which document they are in". The handler
returns `active`, `isTyping`, `cursor`, `lastEdit` — no selection, no
`documentId` (`mcp/awareness.ts:292`, `:306-311`). This is a tool
description, so it is what a model reads before deciding whether to call
it: the cost of the lie is a session asking for a selection this tool
cannot give and then working from `cursor` instead, which is the one
offset in the whole MCP surface that is *not* in the flat coordinate
system.

The description now names the four fields, points at
`tandem_checkInbox`'s `activity.selectedText` for the selection (which
*is* flat), and carries #1776's ProseMirror caveat at the point of use
rather than only in `docs/mcp-tools.md`.

**Bundled, because it is the same defect one layer down:** `isTyping` is
now present on both branches. The no-activity branch omitted it, so a
caller reading the field the description leads with got `undefined`.
That is falsy, so the common `if (!isTyping)` read happened to work and
a `=== false` or `typeof` read silently did not — the failure mode that
survives longest. The new assertion is `toBe(false)`, not a falsy check,
precisely so it cannot pass against the omission it exists to prevent;
mutation-checked by dropping the field and watching it go red.

## `tandem_open` still said "Auto-opens the editor"

#477 removed browser auto-open (`cli/start.ts:22-31`), and nothing on
this path reaches the desktop window's `show_main_window`
(`src-tauri/src/lib.rs:804-805`, reached only from startup, tray/menu,
second-instance launch and macOS's file-open event). The description now
says the tab appears in an editor that is already running — which is the
difference between a session telling the user "opened it, go look" and
one that knows to say where.

## `INTERNAL` and `INTERNAL_ERROR` are two codes for one condition

They are different strings on the wire. `INTERNAL_ERROR` is MCP's
catch-all (`mcp/response.ts:118`); `INTERNAL` belongs to the `/api`
surface, which has its own code vocabulary (`mcp/routes/_shared.ts`, whose
`ERROR_LABELS` list ends in it). The two `never`-exhaustiveness arms on
`tandem_resolveAnnotation` and `tandem_removeAnnotation`
(`mcp/annotations.ts:520`, `:566`) carried the `/api` one, so the MCP
surface had two codes for "a handler fell off the end".

Unreachable while the lifecycle unions stay exhaustive — a new arm is a
compile error at the `never` anchor first — so this is a correction to the
wire contract, not a live bug. Left in place with a comment naming which
surface owns which string, because the obvious tidy is to make them agree
in the wrong direction.

## The npm scrub's docblock claimed an invoker it does not have

`src/cli/uninstall-scrub.ts` opened with "Invoked by the Tauri NSIS
installer hook during uninstall on Windows." It is not. The hook runs
`"$INSTDIR\${MAINBINARYNAME}.exe" --uninstall-scrub`
(`src-tauri/windows/installer-hook.nsi:58`), which is the **desktop**
binary and reaches the Rust `src-tauri/src/uninstall_scrub.rs` — whose own
docblock says so, and says the npm CLI is not among the Tauri `resources`.
Nothing invokes this file automatically on any platform.

Two more sentences in the same docblock were the Rust file's rationale
copied onto a file it does not describe:

- **"Runs inside the already-signed binary … binary-planting target"** is
  the argument for why the *NSIS hook* does not shell out to a separate
  `uninstall_scrub.exe`. This subcommand is reached only by a user typing
  it.
- **"NSIS logs the exit code but does NOT block uninstall"** names a
  consumer that does not exist. Nothing reads this scrub's exit code but
  the user's shell.

The correction that reaches a user is the consequence, now stated:
**neither scrub is a superset of the other.** The Rust one alone removes
the start-at-login registration; this one alone removes the MCP config
entries and the bundled skill. They overlap on the Cowork plugin entries
and firewall rules. So uninstalling the desktop app on Windows leaves
`mcpServers.tandem` in `~/.claude.json` until this is run by hand — and
the old docblock told a reader it had already happened. `docs/cli.md`
already states the true version (corrected in #1902); this is the code
catching up.

The dispatch-site comment in `src/cli/index.ts:106` repeated all three and
gets the same three corrections.

## Examined and deliberately not changed

`describeReplyWriteRefusal`'s `not-repliable` message — "Cannot reply to a
`<type>` annotation; only notes and comments support replies"
(`annotations/lifecycle.ts:374`) — was raised alongside these as
self-contradicting, one arm before `invalid-note` refuses Claude a note
parent. It stays. The arm is produced for `type === "highlight"` only
(`:1289`), and the describer is shared: `mcp/routes/annotation-reply.ts:71`
runs it on the **browser user's** path, where the message becomes a toast
and "notes and comments support replies" is simply true — the user is who
replies in their own note thread (#1000). Rewriting it for Claude would
make the user-facing half wrong to fix a sentence Claude only ever reads
about a highlight.

## Verification

`npm run typecheck` clean (1194 files, 0 errors). `tests/docs/`,
`tests/scripts/`, `license-gate-coverage`, `mcp-schema-dialect` and
`mcp-tool-integration` green — 48 files, 651 tests. Full vitest suite plus
biome and `cargo test` via the pre-push hook. Working tree clean; no
review agents ran, so no probe residue.

`skills/tandem/SKILL.md` was checked and needs no bump: it already directs
sessions to `tandem_checkInbox`'s `activity.selectedText` for the
selection and only reads `isTyping` from `tandem_getActivity`, both of
which stay true.

Refs #1821.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019z7FSDdV1rUQKy1xEMncYQ
