### PR TITLE
docs(license): free public beta, then a 14-day trial before a one-time purchase

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -6,9 +6,16 @@ Parameters
 Licensor:             Bryan Kolb
 Licensed Work:        Tandem (tandem-editor npm package).
                       The Licensed Work is (c) 2026 Bryan Kolb.
-Additional Use Grant: Personal use and individual self-hosting are permitted
-                      solely for evaluation purposes for up to 30 days; continued
-                      or production use requires a paid license from the Licensor.
+Additional Use Grant: Personal use and individual self-hosting of any version of
+                      the Licensed Work released before version 1.0.0 — the public
+                      beta — are permitted without charge and without a time limit.
+
+                      For version 1.0.0 and later, personal use and individual
+                      self-hosting are permitted for evaluation for up to 14 days
+                      from first launch on a given device; continued use after that
+                      requires a paid license from the Licensor. A paid license is
+                      a one-time purchase and does not expire.
+
                       Commercial hosting or resale of the Licensed Work is not permitted.
 Change Date:          The earlier of 2029-06-10 or two years after the public
                       general availability release of this specific version of the

--- a/README.md
+++ b/README.md
@@ -174,7 +174,9 @@ Tandem is close to v1.0, and I keep shipping. [CHANGELOG.md](CHANGELOG.md) recor
 
 ## License
 
-Tandem is free during the public beta. At v1.0 it moves to a one-time paid license, and beta users are grandfathered with a free one. The code is under the Business Source License 1.1 (BUSL-1.1); [LICENSE](LICENSE) has the terms.
+Tandem is free during the public beta — every pre-1.0 release, with no time limit and nothing to activate. At v1.0 it moves to a **one-time paid license** with a **14-day free trial**: install it, use everything for 14 days, then buy once and keep that version forever. There is no subscription and no renewal. The run gate checks a license's signature and nothing else (`src/server/license/verifier.ts`), so the version you paid for keeps running indefinitely; what a license's expiry date governs is the *update window* — how long you keep receiving new versions — never your right to run the copy you have. Beta users are grandfathered with a free license and skip the trial entirely.
+
+The code is under the Business Source License 1.1 (BUSL-1.1); [LICENSE](LICENSE) has the terms, and [docs/licensing-explained.md](docs/licensing-explained.md) explains the mechanism in plain English. None of it is enforced yet — the gate ships dark and flips at v1.0.
 
 **Claiming the beta license:** Tandem has no telemetry, no analytics, and no signup, so there's no list of beta users to work from. I can only grandfather people who tell me they're here. If you've been using the beta, email <support@tandem.ink> with roughly when you first installed it, and I'll send you a free license before enforcement turns on. Activate it as soon as it arrives (Settings → License) rather than filing it away: the pre-v1.0 build tells you licensing isn't enforced yet, which is true, and is exactly why an unactivated key is easy to lose.
 

--- a/docs/licensing-explained.md
+++ b/docs/licensing-explained.md
@@ -60,6 +60,20 @@ The cost is length: you can't make a self-proving document short. So we made
 sure you never have to type it. The email attaches it as a file, and you can
 paste it in one go.
 
+## Before any of that: the public beta is free
+
+Everything on this page describes v1.0 and later. **Every pre-1.0 release is free
+to use, with no time limit and nothing to activate** — the BUSL Additional Use
+Grant in [LICENSE](../LICENSE) says so in as many words, so this is a term you
+are granted rather than an enforcement gap you are getting away with. It is also
+not enforced: the gate ships dark, so a beta build has no trial clock running at
+all and the three states below are unreachable in it.
+
+At v1.0 the gate flips and the 14-day trial starts for new installs. **Beta users
+are grandfathered with a free license and skip the trial entirely** — see the
+claiming instructions in the README, which matter because Tandem has no telemetry
+and therefore no list of beta users to work from.
+
 ## The three states Tandem can be in
 
 1. **Trial** — 14 days from first launch. Everything works. A banner counts down.

--- a/tests/docs/trial-length-claims.test.ts
+++ b/tests/docs/trial-length-claims.test.ts
@@ -1,0 +1,90 @@
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { TRIAL_DAYS } from "../../src/shared/constants.js";
+
+/**
+ * Drift guard: every human-readable statement of the trial length must equal
+ * `TRIAL_DAYS`.
+ *
+ * `shared/constants.ts` already argues why the *code* copies must derive from
+ * one number — "a silent drift between the copy and the enforcement would be an
+ * accusation of bad faith, not a typo" — and the banner, the wall and the CLI
+ * all import it. **Prose could not**, and it drifted exactly as predicted: the
+ * BUSL Additional Use Grant said evaluation was permitted "for up to 30 days"
+ * while the shipped clock was 14, so the legal document and the enforcement
+ * disagreed by a factor of two in the user's favour on paper and against them
+ * in the binary. Nothing detected it for the life of the file; #1821's docs
+ * sweep found it by reading.
+ *
+ * The LICENSE is the reason this test exists rather than a `tests/docs` claim
+ * about a doc: it is the artefact a user is held to, and it is the one file in
+ * the repo that no test had any opinion about.
+ *
+ * **Paragraph-scoped, not file-scoped**, because these files legitimately carry
+ * other day counts (a rotate-token grace window, a backup retention) that have
+ * nothing to do with the trial. A paragraph mentioning "trial" or "evaluation"
+ * is scoped tightly enough that any `N day` inside it is about the trial, and
+ * loosely enough to survive rewording — which a fixed-substring assertion would
+ * not, and a reworded claim is precisely the moment drift gets introduced.
+ *
+ * The presence assertion is the other half: without it, deleting the sentence
+ * passes. A file that stops stating the trial length at all is a change
+ * someone should make on purpose.
+ */
+
+const ROOT = path.resolve(__dirname, "../..");
+
+/** Files that state the trial length to a human. */
+const CLAIM_FILES = ["LICENSE", "README.md", "docs/licensing-explained.md"] as const;
+
+/** A paragraph is about the trial if it says so. */
+const TRIAL_CONTEXT = /trial|evaluat/i;
+
+/** `14 days`, `14-day`, `14 day` — the shapes prose actually uses. */
+const DAY_COUNT = /(\d+)[\s-]+day/gi;
+
+type Claim = { file: string; days: number; excerpt: string };
+
+function collectClaims(file: string): Claim[] {
+  const text = readFileSync(path.join(ROOT, file), "utf8");
+  const claims: Claim[] = [];
+  for (const paragraph of text.split(/\n\s*\n/)) {
+    if (!TRIAL_CONTEXT.test(paragraph)) continue;
+    for (const match of paragraph.matchAll(DAY_COUNT)) {
+      claims.push({
+        file,
+        days: Number(match[1]),
+        excerpt: paragraph.replace(/\s+/g, " ").trim().slice(0, 120),
+      });
+    }
+  }
+  return claims;
+}
+
+describe("trial-length claims track TRIAL_DAYS", () => {
+  it.each(CLAIM_FILES)("%s states the trial length at least once", (file) => {
+    expect(
+      collectClaims(file).length,
+      `${file} no longer states a trial length in any paragraph mentioning a trial or evaluation. ` +
+        `If that is deliberate, remove it from CLAIM_FILES in this test and say why.`,
+    ).toBeGreaterThan(0);
+  });
+
+  it("every stated trial length equals TRIAL_DAYS", () => {
+    const wrong = CLAIM_FILES.flatMap(collectClaims).filter((c) => c.days !== TRIAL_DAYS);
+    expect(
+      wrong,
+      `These say a trial length that is not TRIAL_DAYS (${TRIAL_DAYS}):\n` +
+        wrong.map((c) => `  ${c.file}: "${c.days} day..." in "${c.excerpt}"`).join("\n"),
+    ).toEqual([]);
+  });
+
+  it("the BUSL Additional Use Grant names the trial and the one-time purchase", () => {
+    const license = readFileSync(path.join(ROOT, "LICENSE"), "utf8");
+    // Not a substring check on the whole sentence — just the two commitments
+    // the README makes on the licence's behalf, so the two cannot part ways.
+    expect(license).toMatch(/one-time purchase/i);
+    expect(license).toMatch(/before version 1\.0\.0/i);
+  });
+});


### PR DESCRIPTION
Bryan's licensing decision, 2026-09-08: **free during the public beta;
afterwards a 14-day free trial before a one-time payment.**

The surprise is how little had to change. **The code already implements
exactly this**, dark:

- `TRIAL_DAYS = 14` (`src/shared/constants.ts:13`), imported by the
  banner, the wall and `tandem license` so all three derive from one
  number.
- The clock starts at first launch and expires into `restricted`
  (`src/server/license/license-state.ts:130`).
- The run gate calls `verifyLicenseSignature`, which checks the signature
  and **not** `expiresAt` (`src/server/license/verifier.ts:54-62`, wired
  at `license-state.ts:70`). So a purchase runs the version you bought
  indefinitely, and `expiresAt` governs only the update window. That is a
  one-time payment in the strong sense, already built.

What did not say any of it was the LICENSE.

## The BUSL grant said 30 days; the shipped clock is 14

```
Additional Use Grant: Personal use and individual self-hosting are permitted
                      solely for evaluation purposes for up to 30 days; ...
```

The legal document and the enforcement disagreed by a factor of two —
generous on paper, restrictive in the binary. This is precisely the
failure mode `shared/constants.ts` already argues against for the code
copies: *"a silent drift between the copy and the enforcement would be an
accusation of bad faith, not a typo."* The three code surfaces derive
from one number. Prose could not, and it drifted.

The grant also carried **no beta carve-out at all** — so a beta user was,
read strictly, out of compliance after 30 days while `README.md` promised
them the beta was free. Both halves of Bryan's decision are now terms
rather than an enforcement gap someone is getting away with:

```
Additional Use Grant: Personal use and individual self-hosting of any version of
                      the Licensed Work released before version 1.0.0 — the public
                      beta — are permitted without charge and without a time limit.

                      For version 1.0.0 and later, personal use and individual
                      self-hosting are permitted for evaluation for up to 14 days
                      from first launch on a given device; continued use after that
                      requires a paid license from the Licensor. A paid license is
                      a one-time purchase and does not expire.

                      Commercial hosting or resale of the Licensed Work is not permitted.
```

## README and the explainer

`README.md`'s License section stated the beta and the one-time licence but
not the trial. It now names all three terms, and says what a licence's
expiry actually governs — the update window, never the right to run the
copy you have — with the file that decides it cited, because "one-time
purchase" and "has an expiry date" read as a contradiction until you know
which one the run gate reads.

`docs/licensing-explained.md` gains a short section immediately before
"The three states Tandem can be in". Every state on that page is
**unreachable in a beta build** — the gate ships dark — and a beta reader
had no way to tell that from the page; the nearest hint was a sentence
about beta testers "who never had a trial", 25 lines further down and in
the context of an error message.

## New drift guard

`tests/docs/trial-length-claims.test.ts`. Every paragraph in LICENSE,
README.md or docs/licensing-explained.md that mentions a trial or an
evaluation must state `TRIAL_DAYS` and no other number, and each file must
state it at least once — so deleting the sentence is not a pass.

Paragraph-scoped rather than a fixed substring on purpose: rewording is
when drift gets introduced, and a substring assertion breaks on the
reword rather than on the drift, which trains people to update the
assertion. The scope is tight enough that any `N day` beside the word
"trial" is about the trial, and loose enough to survive a rewrite.

Mutation-checked: restoring `30 days` turns it red, and the failure quotes
the offending sentence back —

```
LICENSE: "30 day..." in "For version 1.0.0 and later, personal use and individual
self-hosting are permitted for evaluation for up to 30 days fro"
```

Before this, **the LICENSE was the one file in the repo that no test had
any opinion about** — and it is the artefact a user is actually held to.

## Deliberately not changed

The `Licensed Work:` parameter still names only `tandem-editor` (the npm
package), not the Tauri desktop app that `CLAUDE.md` calls the primary
distribution. Read strictly, the grant this PR rewrites attaches to a
package most users never install. Widening what a licence covers is the
licensor's call and not a drive-by edit made while fixing the clause above
it, so it is filed as **#1908** to decide before `LICENSE_GATE_ENABLED`
flips — the gate flipping is the first moment any of this is enforceable.
That issue also flags the `Change Date` parameter, written before v1.0 had
a date.

## Verification

`tests/docs/` and `tests/scripts/` green (46 files, 531 tests), full
vitest suite plus biome and `cargo test` via the pre-push hook. No code
paths change: `TRIAL_DAYS` is untouched, no gate moves, and the diff is
`LICENSE`, two `.md` files and one new test.

Refs #1821, #1116, #1908.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019z7FSDdV1rUQKy1xEMncYQ
