### PR TITLE
ci: trigger on merge_group, pinned by both wiring tests (#1827)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,23 @@ on:
   push:
     branches: [master]
   pull_request:
+  # Merge queue. GitHub builds a temporary `gh-readonly-queue/master/...` branch
+  # holding master plus this PR plus everything queued ahead of it, and fires
+  # `merge_group` against it; the PR merges only if the required checks pass
+  # THERE. That is what replaced `strict: true` (require-branches-up-to-date),
+  # which forced a manual `gh pr update-branch` and a full re-run on every open
+  # PR each time any other one merged.
+  #
+  # **Without this trigger the queue does not fail — it HANGS.** No workflow runs
+  # on the merge group, the required checks never report, and each PR sits until
+  # the queue times out and evicts it. Fail-safe (nothing wrong merges) but
+  # totally opaque, and it looks like a GitHub outage rather than a missing
+  # trigger. `tests/scripts/acceptance-harness-wiring.test.ts` and
+  # `windows-acl-proof-wiring.test.ts` both pin this key for that reason.
+  #
+  # Unfiltered, like `pull_request:` above: a `branches:` filter here would
+  # re-create the hang for the branch it excludes.
+  merge_group:
   workflow_dispatch:
 
 # Least privilege for every job here (CodeQL `actions/missing-workflow-permissions`).

--- a/tests/scripts/acceptance-harness-wiring.test.ts
+++ b/tests/scripts/acceptance-harness-wiring.test.ts
@@ -174,6 +174,24 @@ describe("acceptance-harness CI wiring", () => {
     ).toBeNull();
   });
 
+  it("still triggers on the merge queue, unfiltered", () => {
+    // Since the switch from `strict: true` to a merge queue, the PR-time run is
+    // no longer the last word: master's required checks are satisfied by the
+    // `merge_group` run against the temporary queue branch. A workflow that does
+    // not fire there leaves this gate out of the decision that actually merges.
+    //
+    // The failure is silent in the worst way. Nothing reports, so the PR does not
+    // go red -- it sits in the queue until GitHub evicts it on timeout, which
+    // reads as a platform problem. Same reasoning as the `pull_request` pin
+    // above, and the same "the key existing is not enough" caveat: a `branches:`
+    // filter here re-creates the hang for whatever it excludes.
+    expect(Object.keys(workflow.on)).toContain("merge_group");
+    expect(
+      workflow.on.merge_group,
+      "`on.merge_group` has filters: a branch filter can exclude master's queue while leaving this key in place",
+    ).toBeNull();
+  });
+
   it("fetches the tag the harness actually reads, unconditionally", () => {
     // The harness reads its immutable v9 baseline with
     // `git show <tag>:skills/tandem/SKILL.md`, and checkout@v6 is depth-1 and

--- a/tests/scripts/windows-acl-proof-wiring.test.ts
+++ b/tests/scripts/windows-acl-proof-wiring.test.ts
@@ -178,6 +178,20 @@ describe("windows-acl-proof CI wiring", () => {
       "`on.pull_request` has filters: a branch/path filter can exclude PRs to master while leaving this key in place",
     ).toBeNull();
   });
+
+  it("still triggers on the merge queue, unfiltered", () => {
+    // Since the switch from `strict: true` to a merge queue, the run that
+    // satisfies master's required checks is the `merge_group` one against the
+    // temporary queue branch, not the PR-time run. A workflow that does not fire
+    // there leaves this proof out of the decision that actually merges -- and it
+    // fails by HANGING (nothing reports, the PR is evicted on timeout), which
+    // reads as a platform problem rather than a missing trigger.
+    expect(Object.keys(workflow.on)).toContain("merge_group");
+    expect(
+      workflow.on.merge_group,
+      "`on.merge_group` has filters: a branch filter can exclude master's queue while leaving this key in place",
+    ).toBeNull();
+  });
 });
 
 describe("windows-acl-proof spec list", () => {


### PR DESCRIPTION
## What

Adds `merge_group:` to `ci.yml`'s `on:` block, and pins it in both
workflow-wiring tests.

This is **step 1 of 2** for switching `master` from `strict: true`
(require-branches-up-to-date) to a merge queue. Step 2 is the repo setting
itself, and it must come **after** this merges — see Sequencing below.

## Why

`master` carries `strict: true` alongside `enforce_admins: true`, so every
merge marks every other open PR `BEHIND` — a hard block with no bypass for
anyone. It is keyed on the base moving, not on anything conflicting.

Measured, 2026-09-08: #1912 (four markdown files) and #1913 (two new test
files) shared not one path, and still cost a `gh pr update-branch` plus a
fresh full `check` each, twice over. Recent CI runs are 14–18 min wall clock.

A merge queue does that rebase-and-verify itself, on a temporary
`gh-readonly-queue/master/...` branch holding master + this PR + everything
queued ahead of it.

## Why the trigger has to land first

**Without `merge_group` the queue does not fail — it HANGS.** No workflow
runs on the merge group, the required checks (`check`, the three
`rust-test` legs, `windows-acl-proof`) never report, and each PR sits until
the queue times out and evicts it. Fail-safe, in that nothing wrong merges,
but totally opaque: it reads like a GitHub outage rather than a missing key.

GitHub's own docs are unambiguous — "You **must** use the `merge_group`
event to trigger your GitHub Actions workflow when a pull request is added
to a merge queue."

## Why it is unfiltered

Deliberately bare, like the `pull_request:` above it. A `branches:` filter
here re-creates the hang for whichever branch it excludes — and it does so
while leaving the key visibly present in the file. That is why both pins
assert `on.merge_group` is **null**, not merely that the key exists.

## No job-level changes needed

`ci.yml` references no `event.pull_request`, `github.event_name`,
`head_ref` or `base_ref` anywhere, so every job runs identically on a merge
group. Verified by grep across the whole file.

## Tests

Both existing wiring tests gain the pin, mirroring how each already pins
`push` and `pull_request` for the job it guards:

- `tests/scripts/acceptance-harness-wiring.test.ts`
- `tests/scripts/windows-acl-proof-wiring.test.ts`

Mutation tested, both files red on both mutations:

| Mutation | Result |
|---|---|
| Delete `merge_group:` entirely | 2 failed — `expected [ 'push', 'pull_request', … ] to include 'merge_group'` |
| Keep the key, add `branches: [some-other-branch]` | 2 failed — `expected { branches: [ 'some-other-branch' ] } to be null` |

`wrkflw validate .github/workflows/ci.yml` → Valid.

## Sequencing

This PR must be on `master` **before** the merge queue is enabled. Enabling
it first makes the very first queued PR hang.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019z7FSDdV1rUQKy1xEMncYQ
