### PR TITLE
docs(plans): wave 5 closed — and the deferral that dissolved (#1827)

### DIFF
--- a/docs/plans/2026-09-06-open-issues-sweep.md
+++ b/docs/plans/2026-09-06-open-issues-sweep.md
@@ -409,8 +409,8 @@ literal in `tests/skill-instruction-contract.test.ts` moves with it). `Hooks arm
 | 4 | B anchors | #1764 #1765 #1766 #1767 #1622 | `fix/annotation-anchors-1764` | #1916 | — | armed | merged | Launched 2026-09-08 16:07 EDT from Bryan Windows PC (run `wf_5f5691dc-6f2`, probe ports 4918/4919), concurrently with Gc2b. Implementation order was by SEAM, not issue number: `1764 → 1765 → 1767 → 1622 → 1766`. **The spend limit killed the L-tier run at `build` with only #1764 committed** (17 agents, 3.4M tokens) — #1765 was complete, green and merely UNCOMMITTED, and was recovered by hand and mutation-tested rather than regenerated. The remaining three ran as a purpose-built SIX-agent workflow (`wf_8e946f3c-4b2`) against the already-committed specs — 1.1M tokens, because the plan-and-review phase did not need re-running. **That is the shape to reach for whenever a group dies after its specs land.** Its two review lenses independently found the one that mattered: #1766 closed the heading-interior hole for `tandem_edit` and left it open one click away, because `YDocStore.anchorRange` also serves `tandem_comment` WITH `suggestedText` — a rewrite deferred to Accept, which `snapshotContradicts` cannot object to since the snapshot was captured over that exact span. `anchorRange` now takes a REQUIRED `purpose` discriminant rather than an optional boolean. Three more review findings fixed in the same commit (the #1622 watcher opt-OUT had no detector; the #1622 doc paragraph split the error-code table so eight rows including `LICENSE_REQUIRED` rendered as literal text; `dropSplitTail` could empty a 1-unit snapshot and disarm `snapshotContradicts`). The skeptic reproduced **18 of 18** claimed mutations, including the ones that deliberately stay green. `typecheck:tests` was found already RED on the branch (four TS2571 from #1765, invisible to `npm test`) and fixed here. Full suite 10,958 passed. Merged 2026-09-08 21:15 (`7989261d`); all five issues closed; worktree pruned junction-first. **For Bryan, carried forward:** #1632 stays a DECIDE issue and is now downstream of #1764 (a degraded anchor is legible on the wire for the first time); and `anchor` on `tandem_getAnnotations` LANDED HERE, so wave 9 K-server must not plan it again. | **`skill: false` stands, after the scope cut.** Three adversarial rounds grew the specs past the issues, so they were cut back to the issue-named files plus tests: the `skills/tandem/SKILL.md:182` amendment is dropped (with it the `version` bump, both `tests/skill-instruction-contract.test.ts` pins and the `filesTouched` collision with wave 4's **Gc2a**, which is now the only skill-editing group in the wave), as are `AGENTS.md`, `docs/decisions.md`, the three `experiments/` rows and B-1764's `HoistTag`/`refreshAllRanges` options widening. `filesTouched`: `src/server/positions.ts`, `src/server/mcp/{document,annotations,document-store,navigation,output-schemas}.ts`, `src/server/documents/watcher.ts` (comments), `src/shared/snapshot.ts`, `src/shared/positions/ydoc.ts`, `CLAUDE.md` (Critical Rule 6 for #1766, the Y.js/CRDT `relRange` gotcha for #1764), `docs/architecture.md` (#1766), `docs/mcp-tools.md` (the `anchor` field, the snapshot-normalization line), plus the test files each spec names. || 4 | Gc2a position mapping | #1774 #1776 | — | — | — | — | planned-not-started | |
 | 4 | Gc2b keys + a11y | #1775 #1777 #1778 | `fix/keyboard-and-a11y-1777` | #1915 | — | armed | merged | Launched 2026-09-08 16:12 EDT from Bryan Windows PC (run `wf_694303e1-def`, probe ports 4928/4929), concurrently with B — paired with B because they are file-disjoint (server anchors vs client Svelte) and only ONE of the two needs the reserved E2E ports, which is why Gc2a could not be the partner. The first launch attempt was refused by the auto-mode permission classifier; relaunched on Bryan explicit approval. Order `1777 → 1775 → 1778`. **The spend limit killed the run at `build`, but four of the five implementation commits were already on the branch and the fifth was complete, green and merely UNCOMMITTED** — recovered by hand rather than regenerated (13 agents, 2.6M tokens before the stop). 2 plan-review rounds plus a scope cut. Shipped decisions: Ctrl+Enter fixed with a blanket `defaultPrevented` guard at the TOP of the window listener, not inside the accept-or-dismiss handler; the AltGr gate is branch-by-branch across eleven `e.code` chords so the three deliberate Ctrl+Alt chords survive; the six IME guards go through ONE shared `isImeComposing` predicate; `capturedRange` is demoted from `$state` to a plain `let` rather than bridged through `createCoalescingTick` (nothing reactive reads it, and this retires the same latent hazard in the existing `selectionUpdate` subscriber); the slash-menu guard sits in `resolveActiveSlashCommand` so the menu never OPENS inside a code block, and is deliberately blind to inline `code` MARKS; focus traps use the window-listener-in-`$effect` form (SettingsModal precedent) because only that form reaches trapTab recover-focus branch after a click on the dialog own padding drops focus to `<body>`; ALL FOUR aria-modal dialogs fixed, including the two that ship dark behind `BYO_MODELS_ENABLED`. Held out of scope: the #1722 half named in the #1778 body (it is #1824, with its own row). Verified 99 client tests, E2E 409 passed / 10 skipped / 0 failed, typecheck clean, full suite 10,889. Merged 2026-09-08 19:49 (`e7606afb`); all three issues closed; worktree pruned junction-first. **For Bryan:** the AltGr fix makes Ctrl+Alt+S/N/O/W/F/G/Enter/comma/slash/1-9 inert as app shortcuts on EVERY platform (macOS Option is `altKey` too) — he confirmed on 2026-09-08 that none are muscle memory, so the simple gate shipped rather than a `getModifierState(AltGraph)` check; and **the IME and AltGr changes are not verifiable from this machine** (they need a CJK IME in the chat composer and the link editor, and a Polish or German layout), so they rest on reading the fix rather than running it. |
 | 4 | G5′ audience remnants | #1698 #1826 (#1678 already closed; +pin confirming #1656) | `fix/audience-remnants-1698` | #1921 | — | armed | merged | Launched 2026-09-08 as the wave's last group, alone (Gc2a had merged as #1919, so the one-e2e-group-at-a-time constraint no longer bound). **Taken over by hand after ~4.5 h**: the M-tier run was past its two-round PR-review cap and its review loop had begun chasing findings its own fixes introduced, with hours lost to `/code-review` fork deliveries that reached `completed` without their message ever entering the requesting agent's context (one agent: two forks never returned over ~2 h and two status pings; only the third delivered). `TaskStop`, then the six outstanding low findings applied directly — everything was already committed, so nothing was lost. **The general rule this confirms: stop a review loop the moment it starts reviewing its own fixes past the cap; the findings are cheaper to apply by hand than to schedule.**  Two of the six were real defects and both were fail-CLOSED bugs of the same shape — a check written so that an input it did not anticipate produces silence rather than noise:  - **The status gate made an unrecognized status permanently invisible.** `Annotation.status`   types as the three-value enum but the STORED value is a bare `string` — `sanitizeAnnotation`   passes it through unnormalized and the annotations Y.Map is writable by any connected client.   Both spellings of the `"pending"` test then compound: the gate's `=== "pending"` never admits   the record to `tandem_checkInbox`, and the candidates-filter mirror's `!== "pending"` calls it   settled, so it is dropped from range refresh too. No ledger entry is written, so no later poll   and no restart recovers it. Fixed by enumerating the two real end states in one shared   `isSettledStatus` — shared because the gate and its mirror have to agree and nothing else   keeps them in step. - **The `!editor` decline told the user their text had changed.** Both apply failures shared one   callback and one message. The missing-editor arm's reachable route is SOURCE VIEW, which   unmounts Tiptap while the annotations rail stays mounted by design — so Accept is a live button   with no editor behind it, and the message sends the user hunting for an edit nobody made.   `onApplyFailed` now carries `"range" | "no-editor"`, the shape `onUndoFailed` already used.  Two more were corrected as comments, and the correction is the interesting part: the presence sanitizer's docblock justified its narrow scope by saying `lifecycle.reply` had **already** refused a private comment or a highlight. It had not — `withTypingPresence` calls `setPresenceOn` BEFORE invoking the handler, so the marker is broadcast while the seam has refused nothing. The bound still holds on the other half of the argument (the id is caller-supplied, which is order-independent), but the consequence had been stated backwards: at broadcast time `sanitizeAnnotationIdForPresence` is the ONLY ADR-027 check on that path, so the docblock inviting a reader to treat it as belt-and-suspenders was an invitation to reopen #1698. **A safety argument that names the wrong guarantor reads as reassurance and is worse than none.**  Two findings were ANSWERED rather than fixed, which under a self-driving review loop is the outcome that needs a human to hold: the restart residual is the bound the spec deliberately chose (widening it reproduces the storm the gate closed, and it is a duplicate not a loss), and the idempotency window is not widened by the apply-before-accept reorder because `applySuggestion` is synchronous — nothing awaits between the check and the write. The loop would have "fixed" the first one straight back into the defect.  Also recorded on the PR: the status gate is an INTENTIONAL narrowing versus master. A user comment resolved before Claude's first poll used to be returned once (verified — `git show origin/master:src/server/mcp/awareness.ts:674` carries no status term); it is now filtered, so `annotation:created` has no pull counterpart for that record. Accepted, since the push already carried the content. Three of #1826's five items were refuted with evidence rather than fixed, and item 3 — concurrent `map.set` resolving by clientID — got the tracked home its spec required before `Closes #1826` could fire: **#1920**. The issue's own proposed fix (a `version` field with compare-and-set) cannot hold in a CRDT and would report a false guarantee; the real fix is server-serialized annotation writes, an authority change rather than a Low. #1656 was re-checked and is already correct — **no test added, because "already correct" has to be a reportable outcome or the pass is theatre.**  All three behavioural changes mutation-tested red (gate reverted, mirror reverted, reason hardcoded), restoring from file copies rather than `git checkout`. Full suite 650 files / 10,984 passed; typecheck, typecheck:tests and biome clean. One discounted flake: the pre-push `cargo test` failed `bounded_command::times_out_and_actually_kills_the_child` under concurrent vitest load and passed clean in isolation — the same timing class as F-config's, and no Rust was touched here. |
-| 5 | D1 markdown fidelity | #1813 #1751 #1753 #1799 #1852 #1850 + #1823 server-data bullets | — | — | — | — | planned-not-started | |
-| 5 | E1 desktop core | #1761 → #1763+#1812 → #1758+#1787 (+decision D) | — | — | — | — | planned-not-started | **#1761 shrank on 2026-09-08 — re-read it before scoping this group.** A Dependabot bump (`c991b816`) moved `keyring` 3→4, whose default `v1` feature selects the platform store and has no mock fallthrough, so the mock-keychain root cause and the "#1455 root cause" claim are both dead. What is left is a round-trip test plus an `Entry::store_status()` check — S, not the M/L this row was sized on. The E1 *sizing* is now wrong, and #1455 needs re-checking rather than assuming this fixed it. **Decision D shipped gated on `flavor`, not on version ordering** — an already-released `tandem-editor` has no code to read a stamp, so a version rule protects nothing the directory separation has not already made impossible; recorded against D's row in `decisions.md`. |
+| 5 | D1 markdown fidelity | #1813 #1751 #1753 #1799 #1852 #1850 + #1823 server-data bullets | `fix/markdown-fidelity-1753` | #1924 | — | armed | merged | Launched 2026-09-09 in `wt-d1`; 25 agents / 4.34M subagent tokens / ~4.7 h, 3 review rounds + 2 PR-review rounds, 52 files. Six issues closed, #1823 Refs-only (four items named and left to wave 9 K-server). **Two of the six shipped as ANSWERS, not code**: #1852 gets a real-file spec and no serializer change, because hand-authored delimiter geometry is unreproducible — mdast carries no source markers for it — and #1753 half B's own example is *refuted* (`\*not emphasis\*` round-trips byte-identical; the corrupting shape is `\[label]`, via reference definitions arriving as raw-carrier `html` nodes). #1813's fix reverses a CLAUDE.md gotcha: force-open now clears only the in-memory map and flushes the envelope, so durable notes survive, and the Y.js/CRDT bullet is rewritten in-branch. Merged 2026-09-09 13:31 (`818e9c3d`) after one `update-branch`; worktree pruned junction-first. **CodeQL went red and it was NOT the usual timing race** — 3 new HIGH `js/path-injection` at `file-io/index.ts:421-424`, which are the same condition already dismissed as won't-fix three times on that file (#50/#51/#52), relocated because #1850 consolidated `atomicWrite` + `atomicWriteBuffer` into one `writeTempThenRename`. Left OPEN for Bryan rather than dismissed. **The For-Bryan reflow bullet in the PR body was wrong and was corrected in place before merge** — see the wave narrative and #1926. |
+| 5 | E1 desktop core | #1761 → #1763+#1812 → #1758+#1787 (+decision D) | `fix/desktop-core-1761` | #1925 | — | armed | merged | Launched 2026-09-09 in `wt-e1`; re-scoped before planning per this row's own warning — #1761 had shrunk to a round-trip test plus `Entry::store_status()`, and **#1455 is NOT resolved by it** (its own dated gate, 2026-10-15). Five issues closed. **The group STALLED in the `/code-review` fork-delivery failure and was finished by hand** — diagnosed by comparing journals (D1's fresh at 12:34 and progressing; E1's frozen at 12:06 with `code-review:r2` last, while three review agents had completed), confirmed at the filesystem level by two of three review `.output` files being **0 bytes**. Recovery was to grep the one 1.1 MB output that landed rather than re-run a ~200k-token review; every recovered finding was re-derived against current source first, which is what caught that two of the six were already fixed in `7d7f5b91` and their line numbers predated it. An orphan agent that had burned ~430k tokens on wait-loop ticks was stopped after it began unprompted scratchpad exploration; both worktrees verified intact after. Round 2's own headline: a single unreadable legacy file silently disabled #1787 **entirely and permanently**, because `fs.cp` is all-or-nothing and its throw reached the catch that returns WITHOUT writing the ownership stamp — so the guard never armed on that launch or any later one. Also carries the **`ci.yml` apt fix** (`fc689a0c`), bundled because it is what unblocked this PR: see the wave narrative. Merged 2026-09-09 14:12 (`717eeff9`) after one `update-branch` plus one rerun; worktree pruned junction-first. **Decision D shipped gated on `flavor`, not on version ordering** — an already-released `tandem-editor` has no code to read a stamp, so a version rule protects nothing the directory separation has not already made impossible; recorded against D's row in `decisions.md`. |
 | 6 | D2 docx contract | #1754 (Refs) #1755 | — | — | — | — | planned-not-started | |
 | 6 | H the flip | #1788 → #1785 → #1793+#1786 (+#1825 infra section, same ledger row; code only, **no deploy**) → #1789 #1819 — three PRs in the ledger | — | — | — | — | planned-not-started | |
 | 6 | CI-trust | #1862 #1673 | — | — | — | — | planned-not-started | |
@@ -536,6 +536,110 @@ One process cost to avoid repeating: three sibling docs PRs merged serially cost
 `update-branch` cycles and three ~20-minute `check` runs, because `strict: true` invalidates
 the rest of the queue on every merge. Sibling PRs with disjoint files are still worth splitting
 for reviewability, but land them in one queue rather than opening them in parallel.
+
+### Wave 5 opened — 2026-09-09
+
+D1 markdown fidelity and E1 desktop core, launched concurrently. **D1 merged as #1924
+(`818e9c3d`, 13:31); E1 is #1925 and still in flight.** Neither is `e2e: true`, so the
+one-e2e-group-at-a-time constraint did not bind this pair.
+
+**E1 stalled in the same failure mode as G5′, and the diagnosis was a journal comparison.**
+D1's journal was fresh at 12:34 and had progressed `code-review:r2` → `skeptic:r2` →
+`fix:review:r2`; E1's was frozen at 12:06 with `code-review:r2` last, while *three* code-review
+agents had completed on that branch. The filesystem confirmed it: two of the three review
+`.output` files were **0 bytes**. That is the `/code-review` fork-delivery failure — a fork
+reaches `completed`, its output file is empty, the requesting agent never receives the payload,
+and the stage silently retries at ~200k tokens each. **Recovery is to grep the one output that
+DID land, not to re-run the review.** Every recovered finding was then re-derived against
+current source before being touched, which is what caught that two of the six were already
+fixed in the r1 commit — their line numbers predated it. An orphan agent burning ~430k tokens
+on wait-loop ticks was stopped once it began unprompted scratchpad exploration; both worktrees
+were verified intact afterward.
+
+**The wave's real lesson is about a measurement, not a mechanism.** D1's PR body carried a
+For-Bryan bullet reporting that saving a hard-wrapped markdown document *"reflows every
+soft-wrapped paragraph onto one line"*, with three figures: 1503 differing lines in
+`docs/mcp-tools.md`, 432 in the sweep plan, 131 in `CONTRIBUTING.md`. Filing that as an issue
+meant measuring it first, and **all three numbers reproduce exactly while the conclusion drawn
+from them is false.** They come from a *positional* line-index comparison, where one blank line
+inserted near the top of a file marks every line after it as differing. The true diff for
+`docs/mcp-tools.md` is **+126 / −39**; `CONTRIBUTING.md` is **+4 / −3**. There is no paragraph
+reflow at all — hard wraps survive the round trip intact.
+
+What is actually there, measured identically on `master` and on D1's branch: **27 of 30** repo
+`.md` files are rewritten, **all idempotent**, in four rendering-neutral classes — table
+delimiter rows (122 rows, so #1852's class is repo-wide rather than the one README it names),
+a blank line inserted before a fence or list (294), lazy-continuation structure made explicit
+(~207 lines, mostly `docs/decisions.md`), and escape/marker normalization. Filed as **#1926**,
+which also carries the retraction; the PR body was corrected in place before it merged.
+
+Two rules fall out, and they generalise past markdown:
+
+- **A line-index diff is not a diff.** Any count of "differing lines" taken by position is an
+  upper bound dominated by the first insertion, and it will overstate a small change by an
+  order of magnitude. Use `git diff --no-index --numstat`, or classify hunks.
+- **The third class read as corruption on first inspection and is not.** Paragraphs written
+  flush against a preceding blockquote or list item come back *inside* it — but per CommonMark
+  **lazy continuation** they already were, so the serializer is writing what the document
+  meant. Check the spec before filing a round-trip difference as data loss.
+
+**A CodeQL red that was not the timing race.** #1924's CodeQL failure reported 3 new HIGH
+`js/path-injection` alerts, and the memory-rule that a ~3s CodeQL failure is the
+default-setup/rust config race did not apply — the run was 3s AND the finding was real-shaped.
+They resolve to the same condition dismissed as won't-fix three times already on that file
+(#50/#51/#52, "atomicWrite is an internal helper; path validation is caller responsibility"),
+relocated because #1850's fix consolidated `atomicWrite` and `atomicWriteBuffer` into one
+`writeTempThenRename` helper. Not a new vulnerability, CodeQL is not a required check, and the
+alerts were **left open for Bryan rather than dismissed** — dismissing a security alert is his
+call. Checked while there: CLAUDE.md's rule that alert 16 must not be dismissed *as a false
+positive* is intact; it was dismissed 2026-08-28 as "True positive, not false … won't fix per
+#1654", which honours the rule.
+
+**Also: not every red is a semantic conflict.** E1's post-restack `check` and
+`rust-test (ubuntu)` both failed in their dependency-install step, before any Tandem code ran —
+`apt-get update` hit a `Hash Sum mismatch` on Google's Chrome repo. The other two rust legs
+were *cancelled* by fail-fast, not failed. Read the failing STEP before reading the diff.
+
+**Wave 5 is CLOSED — both groups merged 2026-09-09.** D1 markdown fidelity (#1924,
+`818e9c3d`, 13:31) and E1 desktop core (#1925, `717eeff9`, 14:12): eleven issues, plus
+#1823 carried forward as Refs. Both worktrees pruned junction-first; `.claude/worktrees/`
+is empty.
+
+**The reflow retraction did not stay a documentation fix — it turned into an experiment
+that refuted my own follow-up too.** Having established there was no reflow, the remaining
+open half was #1852's: `autoSaveAllToDisk` skips non-dirty documents, so the README it
+reported *was* dirty, and the named suspect was a Tiptap schema normalization on first
+sync. I had written that this "needs a live browser and is not decidable from the server."
+It was decidable, by running it: a Playwright spec that opens a file, attaches a real
+client, waits past first sync and the tab's 500 ms arm window, then asserts no unsaved dot
+and unchanged bytes. Clean — for a fixture carrying all three residual shapes **and for
+#1852's actual README**. Mutation-tested: a real `tandem_edit` before the attach turns it
+red, so it is not passing vacuously. Lands as `tests/e2e/open-does-not-dirty.spec.ts`.
+
+So **the residual is latent, not live**: opening a repo doc costs nothing until a real edit
+provokes a save. That also killed the one fix I had guessed was cheap — class 2's
+blank-line insertion needs a `join` handler that knows the pair was tight in the source,
+and `mdastToYDoc` drops mdast's source positions, so there is nothing to consult at
+serialize time. Same root cause as #1852's delimiter geometry, same answer.
+
+**The rule worth carrying: "not decidable from here" is a claim about the tools you reached
+for, not about the question.** Twice in one wave a deferral was written into a PR body and
+then dissolved in under an hour by actually measuring — once for the reflow numbers, once
+for the browser repro that the deferral itself had specified. Both deferrals were mine, and
+both were cheaper to settle than to hand over.
+
+**Two housekeeping outcomes.** The three CodeQL alerts from #1924's relocated `atomicWrite`
+sinks (#214–216) are **still open**: the auto-mode classifier refuses writes to the
+security-alerts API, so they need Bryan's click. The dismissal wording should NOT inherit
+#50/#51/#52's text verbatim — that said callers "validate at the MCP tool boundary", which
+is now incomplete, because `mcp/annotations.ts` and `mcp/convert.ts` are the caller-named
+destinations *accepted* under #1654 rather than validated. "Won't fix", never "false
+positive", matching alert 16's own framing. And #1926 stays **open** as the tracked
+measurement of the #1448 residual (27 of 30 files, all idempotent, +633/−345, four classes
+with a per-class disposition); closing it is the "accept it" decision, and that is Bryan's.
+
+Wave 6 is the H group, which #1787 has now made real — #1789 documents the env var this
+wave introduced, and it was deliberately sequenced after E1.
 
 ### Wave 0 record
 

--- a/tests/e2e/open-does-not-dirty.spec.ts
+++ b/tests/e2e/open-does-not-dirty.spec.ts
@@ -1,0 +1,115 @@
+import { expect, test } from "@playwright/test";
+import fs from "fs";
+import path from "path";
+import {
+  cleanupAllOpenDocuments,
+  cleanupFixtureDir,
+  createFixtureDir,
+  McpTestClient,
+} from "./helpers";
+
+/**
+ * #1852 / #1926 — merely OPENING a document and letting a browser attach must
+ * not dirty it.
+ *
+ * #1852 reported that autosave rewrote a review README nobody had edited. That
+ * premise cannot be literally true: `autoSaveAllToDisk` skips any document that
+ * is not dirty (#851), so the write means the document WAS dirty. The open
+ * question is what dirtied it, and the leading hypothesis is the client — a
+ * Tiptap schema normalization applied on first sync, which `documents/dirty.ts`
+ * counts like any other body-fragment change because it deliberately does not
+ * gate on transaction origin.
+ *
+ * That hypothesis is not answerable from the server: it needs a real browser
+ * attaching to a real Y.Doc. Hence an E2E rather than a unit test.
+ *
+ * The fixture carries the three shapes #1926 measured as the repo-wide
+ * round-trip residual, so if any of them is what dirties a document this test
+ * is where it surfaces: a hard-wrapped paragraph, a table whose delimiter row
+ * is hand-authored tight, and a bold label sitting flush against a fence with
+ * no blank line between them.
+ */
+test.setTimeout(90_000);
+
+const FIXTURE = `# Round-trip residual shapes
+
+This paragraph is hard-wrapped at roughly eighty columns, the way every
+document under docs/ is written, so that a serializer which reflowed prose
+onto one line would be caught here rather than in a diff nobody reads.
+
+| Code | Trigger |
+|---|---|
+| \`NO_DOCUMENT\` | Tool called before open. |
+
+**Success:**
+\`\`\`json
+{ "ok": true }
+\`\`\`
+`;
+
+let mcp: McpTestClient;
+let tmpDir: string;
+
+test.beforeEach(async () => {
+  mcp = new McpTestClient();
+  await mcp.connect();
+  tmpDir = createFixtureDir();
+});
+
+test.afterEach(async () => {
+  await cleanupAllOpenDocuments(mcp);
+  await mcp.close();
+  cleanupFixtureDir(tmpDir);
+});
+
+test("opening a document and attaching a browser leaves it clean on disk", async ({ page }) => {
+  const file = path.join(tmpDir, "residual-shapes.md");
+  fs.writeFileSync(file, FIXTURE, "utf8");
+
+  const open = (await mcp.callTool("tandem_open", { filePath: file })) as {
+    data: { documentId: string };
+  };
+  const docId = open.data.documentId;
+
+  // Attach a real client. This is the step the server-side reasoning cannot
+  // stand in for: y-prosemirror syncs Tiptap's view of the document into the
+  // Y.XmlFragment, and any normalization it applies is a body change.
+  await page.goto("/");
+  await expect(page.locator(`[data-testid='tab-${docId}']`)).toBeVisible({ timeout: 20_000 });
+
+  // Past the tab's 500 ms arm window and well past first sync.
+  await page.waitForTimeout(3000);
+
+  // The dirty mirror is what the tab renders, and it is the same flag autosave
+  // consults — so an absent dot IS the claim "autosave would skip this".
+  const dot = page.locator(`[data-testid='unsaved-indicator-${docId}'] .dot`);
+  await expect(dot).toHaveCount(0);
+
+  // And the bytes are untouched: no save has been provoked by the attach.
+  expect(fs.readFileSync(file, "utf8")).toBe(FIXTURE);
+});
+
+/**
+ * The same question against the actual document #1852 reported, rather than a
+ * fixture built to resemble it. A synthetic file can only show that the shapes
+ * I thought to include are harmless; this one is the file whose diff started
+ * the issue, so it covers the shapes I did not think of.
+ */
+test("opening the #1852 review README leaves it clean on disk", async ({ page }) => {
+  const source = path.join(process.cwd(), "docs/reviews/2026-09-02-v1-review/README.md");
+  const original = fs.readFileSync(source, "utf8");
+  const file = path.join(tmpDir, "v1-review-README.md");
+  fs.writeFileSync(file, original, "utf8");
+
+  const open = (await mcp.callTool("tandem_open", { filePath: file })) as {
+    data: { documentId: string };
+  };
+  const docId = open.data.documentId;
+
+  await page.goto("/");
+  await expect(page.locator(`[data-testid='tab-${docId}']`)).toBeVisible({ timeout: 20_000 });
+  await page.waitForTimeout(3000);
+
+  await expect(page.locator(`[data-testid='unsaved-indicator-${docId}'] .dot`)).toHaveCount(0);
+  expect(fs.readFileSync(file, "utf8")).toBe(original);
+});


### PR DESCRIPTION
Closes out wave 5 of the open-issues sweep (#1827): ledger rows for both groups, the closing narrative, and the E2E regression test that settles the half of #1852 the D1 PR deferred.

## Why the test is in this PR

D1's spec said the "what dirtied an unedited document" question had to be posted to #1852 before the issue closed, because a deferral living only in a PR body on a closed issue is untracked. Answering it properly turned out to mean *running* it rather than describing it, so the answer is a test — which makes it this wave's deferred deliverable rather than a separate change.

## What the test establishes

`tests/e2e/open-does-not-dirty.spec.ts` opens a file, attaches a real browser client, waits past first sync and the tab's 500 ms arm window, then asserts the tab shows no unsaved dot and the bytes on disk are unchanged. The dot renders the `Y_MAP_DIRTY` mirror of the same flag `autoSaveAllToDisk` consults, so an absent dot is exactly the claim "autosave would skip this document".

Two cases: a fixture carrying the three shapes #1926 measured as the repo-wide round-trip residual (hard-wrapped prose, a tight `|---|---|` delimiter row, a bold label flush against a fence), and **#1852's actual README** copied into the fixture dir — because a synthetic file can only clear the shapes I thought to include.

Both clean. That **refutes the Tiptap-first-sync hypothesis I had written into #1852 myself**, and it means the round-trip residual is latent rather than live: opening a repo doc costs nothing until a real edit provokes a save.

Mutation-tested rather than trusted: inserting a real `tandem_edit` before the attach turns the assertion red (`Expected: 0, Received: 1`), so the test can see a dirty document. Restored from a file copy afterward, never `git checkout`.

## Conflict resolution worth checking

The rebase hit a real semantic conflict, not a whitespace one: #1925 had itself edited the E1 planning row to record that **decision D shipped gated on `flavor` rather than on version ordering**. My merged row would have deleted that sentence. It is carried into the merged row instead — worth a look, since it is the one piece of this diff that came from someone else's branch.

## Two items deliberately left open

- **CodeQL #214–216** — the relocated `atomicWrite` sinks from #1924. The auto-mode classifier refuses writes to the security-alerts API, so these need a human. The narrative records the wording, and specifically that #50/#51/#52's text must **not** be inherited verbatim: it says callers "validate at the MCP tool boundary", which is now incomplete, because `mcp/annotations.ts` and `mcp/convert.ts` are the caller-named destinations *accepted* under #1654 rather than validated. "Won't fix", never "false positive".
- **#1926** stays open as the tracked measurement of the #1448 residual — 27 of 30 files, all idempotent, +633/−345, four classes each with a disposition. Closing it is the "accept it" decision, and that is yours.

## Verification

- `npx playwright test tests/e2e/open-does-not-dirty.spec.ts` — 2 passed, plus the mutation run above.
- Full pre-push gate green (biome + vitest + `cargo test`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019z7FSDdV1rUQKy1xEMncYQ
