### PR TITLE
docs(plans): second budget cut — plan rounds L 3→2, M 2→1 (#1827)

### DIFF
--- a/docs/plans/2026-09-06-open-issues-sweep.md
+++ b/docs/plans/2026-09-06-open-issues-sweep.md
@@ -124,7 +124,7 @@ any stage after `review` short-circuits on `parked` or `failed`. Side effects ar
 before creating; `args.known` lets a resumed run skip.
 
 ```
-plan → reviewLoop(S 1 / M 2 / L 3) → implement → simplify → verify(+fix ≤2) → [e2e] → manualProbes
+plan → reviewLoop(S 1 / M 1 / L 2, + scope cut at every tier) → implement → simplify → verify(+fix ≤2) → [e2e] → manualProbes
      → prReviewLoop(≤2, one batched skeptic) → ship(push, PR, auto-merge-or-record, subscribe)
 ```
 
@@ -137,6 +137,44 @@ lens speak only in round 1 (rules + tests re-check revisions), runs PR review fo
 skeptic judging the round's findings as a batch, drops L's domain effort to `high`, and has no
 post-ship stage. Expected on a J2-shaped group: ~50 agents → ~20. Stage numbers below are the
 post-cut shape; the ledger rows for wave 1–3 groups were run under the old one.
+
+**Second budget cut (2026-09-10, wave 7).** Re-measured per-agent from the run journals on G8
+(L) and I-release (M). The wave-3 cut held its shape but not its conclusion: plan review is
+still the largest line at **45% and 57% of group output** (90M and 98M cached-input of 246M /
+182M), while build, verify, probes, simplify and ship together stayed under a third.
+
+What this measurement adds is a **yield** number the first one did not have. Plan review
+produced **none** of the defects that mattered in either group. Every real finding came from PR
+review, against real code: G8's cold-open gap and the reply-loss **regression its own round-1 fix
+introduced**, and I-release's `make_latest`, the `realpathSync` throw, the unpaginated asset
+listing and the loose `"npm ci"` substring match.
+
+And the rounds do not converge. Blocking counts per round, four groups:
+
+| group | r1 | r2 | r3 | cut |
+|---|---|---|---|---|
+| G8 (L) | 3, 3, 2 | 4, 1 | 2, 6 | 3, 3 |
+| I-release (M) | 3, 3, 2 | 3, 2 | — | 4, 4 |
+| H-c (M) | 2, 4, 2 | 4, 4 | — | 1, 1 |
+| H-b (L) | 4, 2, 6 | 4, 4 | 2, 3 | 2, 1 |
+
+No round ever returns zero, because an agent told to refute always refutes. The loop terminates
+only because `revise:post-cut` is trusted to adopt whatever the last round said — in all four
+groups the cut round found blocking, revise adopted it, and **nothing ever parked**. The count is
+a property of the prompt, not of the plan's quality, so additional rounds buy nothing measurable.
+
+So: **L 3 → 2, M 2 → 1, S stays 1**, and the post-cut re-refute drops from two lenses to one
+(rules — the cut's own failure mode is "removed a mechanism a rule required"). The scope cut now
+runs at **every** tier, where it used to be skipped below two rounds; with M at one round that
+skip would have taken it away from most of the remaining groups, and the cut is the half of that
+block worth keeping — it makes plans smaller, where the refuters only make them longer.
+
+`PR_ROUNDS` stays at 2 and **must not be cut to pay for anything.** G8's PR round 2 is what caught
+the data-loss regression that round 1's own fix introduced; shipping without it would have put a
+bug in the user's `.docx` that is worse than the one the group existed to fix.
+
+Expected saving: **~15% of an L group and ~24% of an M group**, in both output and cached input,
+taken entirely from the stage with no demonstrated yield.
 
 Stages:
 

--- a/docs/plans/2026-09-06-open-issues-sweep.workflow.js
+++ b/docs/plans/2026-09-06-open-issues-sweep.workflow.js
@@ -78,7 +78,29 @@ const M = pickModels(g.tier);
 // only (rules + tests carry the later rounds), PR review is two rounds, and one skeptic judges
 // a round's findings as a batch. L's domain effort dropped from `max` to `high` — C spent more
 // on plan refutation alone than J2 spent end to end.
-const PLAN_ROUNDS = g.tier === "S" ? 1 : g.tier === "L" ? 3 : 2;
+// Re-measured 2026-09-10 on wave 7 (G8 tier L, I-release tier M), per-agent from the run
+// journals. Plan review was 45% and 57% of group OUTPUT and 36%/54% of input — still the
+// largest line, and the wave-3 capping did not change that. What the second measurement adds
+// is a yield number the first one did not have: plan review produced NONE of the defects that
+// mattered in either group. Every real finding came from PR review, against real code — G8's
+// cold-open gap and its reply-loss REGRESSION, I-release's `make_latest`, the `realpathSync`
+// throw, the unpaginated listing and the loose `"npm ci"` substring match.
+//
+// And the rounds do not converge. Blocking counts per round across four measured groups:
+//   G8        r1 3,3,2  r2 4,1  r3 2,6  cut 3,3
+//   I-release r1 3,3,2  r2 3,2          cut 4,4
+//   H-c       r1 2,4,2  r2 4,4          cut 1,1
+//   H-b       r1 4,2,6  r2 4,4  r3 2,3  cut 2,1
+// No round ever returns zero, because an agent told to refute always refutes. The loop
+// terminates only because `revise:post-cut` is trusted to adopt; in all four groups the cut
+// round found blocking, revise adopted it, and nothing parked. So MORE ROUNDS BUY NOTHING
+// MEASURABLE — the count is a property of the prompt, not of the plan's quality.
+//
+// Therefore: L 3 -> 2, M 2 -> 1, S stays 1, and the post-cut re-refute drops from two lenses
+// to one (below). PR_ROUNDS stays at 2 and should NOT be cut to pay for anything: G8's round 2
+// is what caught the data-loss regression that round 1's own fix introduced. This moves budget
+// from the stage with no demonstrated yield to the stage that finds the bugs.
+const PLAN_ROUNDS = g.tier === "L" ? 2 : 1;
 const PR_ROUNDS = 2;
 
 // ---------------------------------------------------------------------------------------
@@ -416,11 +438,14 @@ Rewrite the affected sections of the specs in place (do not leave the old text),
   if (blocking.length === 0 && deadLenses.length === 0) break;
 }
 // Scope-cut round: findings surviving every capped round usually means the plan grew machinery
-// the issue never asked for. Cut to the minimal fix once, re-refute once, then park. An S group
-// gets one round, so its `blocking` list is the pre-revise one — it skips the cut and goes
-// straight to the two-lens re-refute, which is what checks that the revise landed.
+// the issue never asked for. Cut to the minimal fix once, re-refute once, then park.
+//
+// The cut now runs at EVERY tier (2026-09-10). It used to be skipped below two rounds, which
+// was fine while only S sat there; with M at one round that skip would have taken the cut away
+// from most of the remaining groups, and the cut is the half of this block worth keeping — it
+// makes plans smaller, where the refuters only make them longer.
 if (blocking.length > 0) {
-  const cut = PLAN_ROUNDS < 2 ? { ok: true, adopted: [], notAdopted: [] } : await run(
+  const cut = await run(
     "scope-cut",
     `You are the planning agent. ${round} adversarial rounds still leave blocking findings on the specs below, which means the plan has grown beyond the issues. CUT IT TO THE MINIMAL FIX.
 ${GROUP}
@@ -436,9 +461,14 @@ Rewrite each spec so that: it changes only the files the issue names (plus a tes
   if (cut.ok) {
     round += 1;
     result.reviewRounds = round;
+    // ONE lens, not two (2026-09-10). This re-refute exists to check the cut landed, and the
+    // park gate below is what makes it load-bearing — so it stays. But two lenses cost ~65-70k
+    // output per group and, measured across four groups, never once disagreed in a way that
+    // changed the outcome: both always returned blocking, `revise:post-cut` always adopted,
+    // nothing ever parked. Rules is the surviving lens because the cut's own failure mode is
+    // "removed a mechanism a rule required", which is what it reads for.
     const again = (await parallel([
       () => run("review", refuterPrompt(LENS_RULES), { label: `refute:rules:cut`, phase: "Review", model: M.review, effort: "high", schema: S_FINDINGS }, { blocking: [], nonBlocking: [] }),
-      () => run("review", refuterPrompt(LENS_TESTS), { label: `refute:tests:cut`, phase: "Review", model: M.review, effort: "high", schema: S_FINDINGS }, { blocking: [], nonBlocking: [] }),
     ])).filter(Boolean);
     blocking = again.flatMap((f) => f.blocking || []);
     log(`scope-cut round: ${blocking.length} blocking`);


### PR DESCRIPTION
## Summary

A second budget cut on the sweep workflow, to keep waves 7–11 inside the weekly usage limit. Plan review rounds go **L 3 → 2, M 2 → 1** (S unchanged at 1), the post-cut re-refute drops from two lenses to one, and the scope cut now runs at **every** tier rather than being skipped below two rounds.

Ledger-only plus the workflow script; no source, test or CI change.

## Why, measured rather than argued

Re-measured per-agent from the wave-7 run journals — G8 (tier L, `wf_434e1fd6-6b4`) and I-release (tier M, `wf_91102fda-386`).

Plan review is still the largest line: **45% and 57% of group output**, 90M and 98M cached input of 246M / 182M. The wave-3 cut changed its size, not its rank.

What this measurement adds is a **yield** number the first one did not have. **Plan review produced none of the defects that mattered in either group.** Every real finding came from PR review, against real code:

- G8 — the cold-open gap, and the reply-loss **regression that round 1's own fix introduced**.
- I-release — `make_latest` missing from the reuse-branch PATCH, the `realpathSync(process.argv[1])` throw, the unpaginated asset listing, and a `"npm ci"` substring match loose enough to redden required `check` from a comment.

And the rounds do not converge. Blocking counts per round, across four measured groups:

| group | r1 | r2 | r3 | cut |
|---|---|---|---|---|
| G8 (L) | 3, 3, 2 | 4, 1 | 2, 6 | 3, 3 |
| I-release (M) | 3, 3, 2 | 3, 2 | — | 4, 4 |
| H-c (M) | 2, 4, 2 | 4, 4 | — | 1, 1 |
| H-b (L) | 4, 2, 6 | 4, 4 | 2, 3 | 2, 1 |

No round ever returns zero, because an agent told to refute always refutes. The loop terminates only because `revise:post-cut` is trusted to adopt whatever the last round said — in all four groups the cut round found blocking, revise adopted it, and **nothing has ever parked**. The count is a property of the prompt, not of the plan's quality, so more rounds buy nothing measurable.

## What is deliberately NOT cut

**`PR_ROUNDS` stays at 2.** G8's round 2 is what caught the data-loss regression its own round-1 fix introduced; shipping without it would have put a defect into a user's `.docx` worse than the one that group existed to fix. This change moves budget *toward* PR review, not away from it.

The scope cut is kept and widened for the same reason its refuters are trimmed: it is the one agent in that block that makes a plan *smaller*.

## Expected saving

~15% of an L group and ~24% of an M group, in both output and cached input, taken entirely from the stage with no demonstrated yield.

## Cache-safety note for anyone resuming a run

This edit changes `PLAN_ROUNDS`, which is read before any `agent()` call in the review loop. Per the wave-3 lesson (ledger, "A resume is only cache-safe if the earlier `agent()` calls are byte-identical"), **no run started before this commit can be resumed with `resumeFromRunId` across it** — it would re-run plan review from scratch rather than replaying from cache. Both wave-7 groups are merged, so nothing is in flight.

## Verification

- Script parses as an async function body (top-level `return`/`await` are the runtime's shape, so `node --check` is the wrong tool and reports a false `Illegal return statement`)
- `docs/**` is outside biome's include set, so lint does not cover this file — checked deliberately rather than assumed
- `npm run typecheck:tests`, full vitest and `cargo test` green via the pre-push hook

Refs #1827

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019z7FSDdV1rUQKy1xEMncYQ
