### PR TITLE
docs(plans): schedule #1941 as wave 10 D3; drop closed #1292 from wave 11 (#1827)

### DIFF
--- a/docs/plans/2026-09-06-open-issues-sweep.md
+++ b/docs/plans/2026-09-06-open-issues-sweep.md
@@ -109,8 +109,9 @@ one wave are file-disjoint (checked against the ledgers); each is its own `Workf
 | 9 | #1603 transform audit | #1603 | M [security] | |
 | 10 | G4 typecheck-tests | #1613 → #1614 → #1615 (alone) | S/M | |
 | 10 | G11 process docs | #1602 #1604 #1605 #1606 | S | CLAUDE.md edits — last, to limit conflicts. |
+| 10 | D3 docx save override | #1941 | M [security] | **Added 2026-09-11** — was open-by-design out of wave 6 (D2 shipped the refusal; this is the escape hatch) and had no row, so it was scheduled nowhere. Wave 10, not 8/9: it adds a `/api/save` body field (collides with K-sec-server's `api-routes.ts` work) and a `tandem_save` param + `docs/mcp-tools.md` line (collides with K-server). Both surfaces — the flag AND `FidelityReportBanner.svelte`'s "Save anyway" — or a browser user with no Claude attached still has no exit. `e2e` + screenshots. Keep `blockReasonMessage` content-free; do **not** extend the override to `tandem_applyChanges`. |
 | 11 | #1689 harness refactor | #1689 | M | After G4. |
-| 11 | local-model flip blockers | #1657 #1292 | M [security] | Only after Bryan re-decides #1292's severity. |
+| 11 | local-model flip blockers | #1657 | M [security] | **Re-scoped 2026-09-11: #1292 is out — fixed and CLOSED 2026-09-08**, its severity re-decision made rather than still owed, so the "only after Bryan re-decides" gate this row carried is gone and the group is now #1657 alone. |
 | 11+ | decision rounds | the ~30 DECIDE issues, 4 at a time | per item | |
 
 ## Workflow architecture
@@ -472,8 +473,9 @@ literal in `tests/skill-instruction-contract.test.ts` moves with it). `Hooks arm
 | 9 | #1603 transform audit | #1603 | — | — | — | — | planned-not-started | |
 | 10 | G4 typecheck-tests | #1613 → #1614 → #1615 (alone) | — | — | — | — | planned-not-started | |
 | 10 | G11 process docs | #1602 #1604 #1605 #1606 | — | — | — | — | planned-not-started | |
+| 10 | D3 docx save override | #1941 | — | — | — | — | planned-not-started | Added 2026-09-11; see the wave table for why wave 10 and not 8/9. |
 | 11 | #1689 harness refactor | #1689 | — | — | — | — | planned-not-started | |
-| 11 | local-model flip blockers | #1657 #1292 | — | — | — | — | planned-not-started | |
+| 11 | local-model flip blockers | #1657 | — | — | — | — | planned-not-started | #1292 removed 2026-09-11 — closed as fixed 2026-09-08. |
 
 ### Wave 3 closed — 2026-09-08
 
@@ -778,7 +780,8 @@ half — a red that reads as a floor breach; #1937 carries the vitest exit-1-wit
 half), #1754 → decision B, #1825 (its Infra section is 2-of-3 and the CI/build `infra/` bullet is
 done; the rest of CI/build, all of Tauri and the Tests remainder are wave 7), #1941 (the `.docx`
 save override — Bryan's explicit choice of *refuse by default, add an override*, split out rather
-than stacked so the safety half shipped first),
+than stacked so the safety half shipped first; **scheduled 2026-09-11 as wave 10 group D3** — it
+sat here for a day as prose with no wave row, which is a backlog slot by another name),
 #1942 (signing-key rotation, dated), #1943 (deactivation policy, Bryan's), #1946 (the desktop
 token panel, found while fixing #1789(a)).
 


### PR DESCRIPTION
## Summary

Two defects in the sweep ledger, same class: a fact changed and the schedule did not follow it. Docs only — `docs/plans/2026-09-06-open-issues-sweep.md` alone, no source, test or CI change.

## #1941 had no wave row

It came out of wave 6 as *open by design* — D2 (#1939) shipped the `.docx` image-loss **refusal**, and #1941 is the explicit **override** Bryan asked for alongside it, split out rather than stacked so the safety half was not held up by the escape hatch. That was the right call. But it was recorded only as prose in the wave-6 closeout, and prose in a closed wave's notes is a backlog slot by another name: every other piece of tracked work in this sweep has a row, and nothing would ever have picked this one up.

It is not a decision waiting on Bryan. He already made the decision — *refuse by default, add an override* — and #1941 is a complete implementation spec: the `allowImageLoss` flag on `saveDocumentToDisk`, plumbed to `tandem_save` and `POST /api/save`, plus a "Save anyway" affordance in `FidelityReportBanner.svelte`. Both halves, because the flag alone moves the dead end rather than removing it: a browser user with no Claude attached still has no way through.

Scheduled as **wave 10, group D3**.

**Why wave 10 and not 8 or 9 — file collisions, not size.** #1941 adds a body field to `POST /api/save`, and wave 8's K-sec-server owns `api-routes.ts`; it adds a `tandem_save` param and its `docs/mcp-tools.md` line, and wave 9's K-server owns that file. Wave 10's two existing groups — G4 typecheck-tests and G11 process docs — touch neither. The row carries the three constraints from the issue that are easy to lose: keep `blockReasonMessage` content-free (`SAVE_ERROR_CODE_SUFFIX_EXEMPT`), do **not** extend the override to `tandem_applyChanges` (`docx-apply.ts` edits `word/document.xml` in place and re-zips, so pictures survive it — an override there would be meaningless), and the override must not become a way to write to a caller-named destination, because #1654's accepted bound still applies.

## Wave 11's local-model row still gated on a decision that was made

The row read: `#1657 #1292 | Only after Bryan re-decides #1292's severity.`

That re-decision happened. **#1292 was fixed and closed 2026-09-08** — #1340 replaced the whole-value re-`set` with delta splices into a per-message `Y.Text`, and the severity call was made rather than still owed. PR #1969 reconciled that in `CLAUDE.md` and `docs/security.md` earlier today; this is the same correction reaching the schedule. The gate is gone and the group is **#1657 alone**.

This one matters beyond tidiness: a wave row that says "only after Bryan decides X" is exactly the kind of line that reads as a live blocker to whoever picks the wave up, and it had been stale for three days.

## Verification

`npx vitest run tests/docs` — 27 files, 199 tests, all passing. No test reads this file (it is a planning ledger, not a pinned document), so the suite confirms nothing was broken rather than confirming the edit; the claims themselves were checked against `gh`:

- `#1941 OPEN` — "docx image-loss save: add the explicit override to the refusal (Bryan, 2026-09-10)"
- `#1292 CLOSED` — 2026-09-08
- `#1657 OPEN` — "local-model `stillOwner()` checks document presence, not identity"

## Refs

Refs #1827 — the sweep tracking issue.
Refs #1941 — no work; this gives it the wave row it never had.
Refs #1292 — no work; closed 2026-09-08. This removes the last place the schedule still treated it as pending.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019z7FSDdV1rUQKy1xEMncYQ
